### PR TITLE
feat[CWPP-510] Enable unit consumption per ECS container

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -5,7 +5,7 @@ export const UNIT_MAPPING = {
       "AWS::EC2::Instance": 10,
     },
     Lambda: { "AWS::Lambda::Function": 10 },
-    ECS: { "AWS::ECS::Cluster": 10 },
+    ECS: { "AWS::ECS::TaskDefinition": 10 },
   },
 };
 


### PR DESCRIPTION
Summary:
Currently, we were charging customer per ECS task definition. We now want to bill customer per AWS::ECS::TaskDefinition ContainerDefinition as we each of containers in a TaskDefinition.

In this PR, we acknowledge count of containers in AWS::ECS::TaskDefinition.


**Developer testing**

Testing in `us-west-2` region only that had 1 ECS service, 1 Cluster and 1 task definition(with 2 containers definition). 
 = > `node index.js -p AWS -s ECS`
`AWS_MAPPING` looks like:
```json
{
  "total": 4,
  "ECS": {
    "AWS::ECS::Cluster": 1,
    "AWS::ECS::Service": 1,
    "AWS::ECS::TaskDefinition": 2,
  },
}
```

and `AWS-output.json` file looks like:
```json
{
  "TOTAL": 4,
  "CSPM_UNITS": 4,
  "CWPP_UNITS": 20,
  "TOTAL_UNITS": 24,
  "DAYS_PER_MONTH": 30,
  "CSPM_UNITS_PER_MONTH": 120,
  "CWPP_UNITS_PER_MONTH": 600,
  "TOTAL_UNITS_PER_MONTH": 720,
  "INFO": {
    "CSPM_CIEM_ASSET_UNIT_BASE_CONSUMPTION": 1,
    "CWPP_ASSET_UNIT_BASE_CONSUMPTION": 10,
    "TOTAL_DAYS_PER_MONTH": 30
  },
  "DAILY": {
    "CSPM_CIEM_ASSET_UNITS": 4,
    "CWPP_ASSET_UNITS": 20,
    "TOTAL_ASSET_UNITS": 24
  },
  "MONTHLY": {
    "CSPM_CIEM_ASSET_UNITS": 120,
    "CWPP_ASSET_UNITS": 600,
    "TOTAL_ASSET_UNITS": 720
  }
}
```