### PR TITLE
feat: CSPM-1842 Ensure VPC uses Network Firewall

### DIFF
--- a/AWS/aws-dependencies.json
+++ b/AWS/aws-dependencies.json
@@ -1286,5 +1286,24 @@
         }
       }
     ]
+  },
+  {
+    "id": "NetworkFirewall",
+    "resources": [
+      {
+        "resourceType": "AWS::NetworkFirewall::Firewall",
+        "list": {
+          "action": {
+            "command": "paginateListFirewalls",
+            "outputProperty": "Firewalls"
+          }
+        },
+        "listClientConfig": {
+          "clientName": "NetworkFirewallClient",
+          "clientType": "AWS_V3",
+          "packageName": "@aws-sdk/client-network-firewall"
+        }
+      }
+    ]
   }
 ]

--- a/AWS/aws-services.json
+++ b/AWS/aws-services.json
@@ -2098,5 +2098,47 @@
       "me-south-1",
       "us-east-2"
     ]
+  },
+  {
+    "service": "NetworkFirewall",
+    "scope": "AWSAccount",
+    "resources": [
+      {
+        "resource": "Firewall",
+        "resourceType": "AWS::NetworkFirewall::Firewall"
+      }
+    ],
+    "regions": [
+      "ap-east-1",
+      "ap-northeast-3",
+      "ap-south-2",
+      "ap-southeast-2",
+      "eu-central-1",
+      "me-central-1",
+      "us-east-1",
+      "us-gov-east-1",
+      "us-gov-west-1",
+      "us-west-1",
+      "ap-northeast-2",
+      "cn-north-1",
+      "cn-northwest-1",
+      "eu-south-1",
+      "eu-south-2",
+      "eu-west-1",
+      "eu-west-2",
+      "eu-west-3",
+      "sa-east-1",
+      "us-west-2",
+      "af-south-1",
+      "ap-northeast-1",
+      "ap-south-1",
+      "ap-southeast-1",
+      "ap-southeast-3",
+      "ca-central-1",
+      "eu-central-2",
+      "eu-north-1",
+      "me-south-1",
+      "us-east-2"
+    ]
   }
 ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,6 +48,7 @@
         "@aws-sdk/client-memorydb": "^3.347.1",
         "@aws-sdk/client-mq": "^3.347.1",
         "@aws-sdk/client-neptune": "^3.347.1",
+        "@aws-sdk/client-network-firewall": "^3.347.1",
         "@aws-sdk/client-opensearch": "^3.347.1",
         "@aws-sdk/client-organizations": "^3.347.1",
         "@aws-sdk/client-rds": "^3.347.1",
@@ -2117,6 +2118,425 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@aws-sdk/client-network-firewall": {
+      "version": "3.386.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-network-firewall/-/client-network-firewall-3.386.0.tgz",
+      "integrity": "sha512-kU95pDg6XDBJC2i1UzipdmLEV7bTn8+BdfMFbBykP8JK7ydEGh0oJeicydC79K6+d2gVajZxykfuzmmLLLhVdQ==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/client-sts": "3.386.0",
+        "@aws-sdk/credential-provider-node": "3.386.0",
+        "@aws-sdk/middleware-host-header": "3.379.1",
+        "@aws-sdk/middleware-logger": "3.378.0",
+        "@aws-sdk/middleware-recursion-detection": "3.378.0",
+        "@aws-sdk/middleware-signing": "3.379.1",
+        "@aws-sdk/middleware-user-agent": "3.386.0",
+        "@aws-sdk/types": "3.378.0",
+        "@aws-sdk/util-endpoints": "3.386.0",
+        "@aws-sdk/util-user-agent-browser": "3.378.0",
+        "@aws-sdk/util-user-agent-node": "3.378.0",
+        "@smithy/config-resolver": "^2.0.1",
+        "@smithy/fetch-http-handler": "^2.0.1",
+        "@smithy/hash-node": "^2.0.1",
+        "@smithy/invalid-dependency": "^2.0.1",
+        "@smithy/middleware-content-length": "^2.0.1",
+        "@smithy/middleware-endpoint": "^2.0.1",
+        "@smithy/middleware-retry": "^2.0.1",
+        "@smithy/middleware-serde": "^2.0.1",
+        "@smithy/middleware-stack": "^2.0.0",
+        "@smithy/node-config-provider": "^2.0.1",
+        "@smithy/node-http-handler": "^2.0.1",
+        "@smithy/protocol-http": "^2.0.1",
+        "@smithy/smithy-client": "^2.0.1",
+        "@smithy/types": "^2.0.2",
+        "@smithy/url-parser": "^2.0.1",
+        "@smithy/util-base64": "^2.0.0",
+        "@smithy/util-body-length-browser": "^2.0.0",
+        "@smithy/util-body-length-node": "^2.0.0",
+        "@smithy/util-defaults-mode-browser": "^2.0.1",
+        "@smithy/util-defaults-mode-node": "^2.0.1",
+        "@smithy/util-retry": "^2.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-network-firewall/node_modules/@aws-sdk/client-sso": {
+      "version": "3.386.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.386.0.tgz",
+      "integrity": "sha512-UBgRo0q/XSle9CHCpoFhzq9wCfdc4kJw40cpPoHJPbb5m3JMcDu0mq4LTY7Nwnoy9jBThfRVYf3EF2BMF8fo6A==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/middleware-host-header": "3.379.1",
+        "@aws-sdk/middleware-logger": "3.378.0",
+        "@aws-sdk/middleware-recursion-detection": "3.378.0",
+        "@aws-sdk/middleware-user-agent": "3.386.0",
+        "@aws-sdk/types": "3.378.0",
+        "@aws-sdk/util-endpoints": "3.386.0",
+        "@aws-sdk/util-user-agent-browser": "3.378.0",
+        "@aws-sdk/util-user-agent-node": "3.378.0",
+        "@smithy/config-resolver": "^2.0.1",
+        "@smithy/fetch-http-handler": "^2.0.1",
+        "@smithy/hash-node": "^2.0.1",
+        "@smithy/invalid-dependency": "^2.0.1",
+        "@smithy/middleware-content-length": "^2.0.1",
+        "@smithy/middleware-endpoint": "^2.0.1",
+        "@smithy/middleware-retry": "^2.0.1",
+        "@smithy/middleware-serde": "^2.0.1",
+        "@smithy/middleware-stack": "^2.0.0",
+        "@smithy/node-config-provider": "^2.0.1",
+        "@smithy/node-http-handler": "^2.0.1",
+        "@smithy/protocol-http": "^2.0.1",
+        "@smithy/smithy-client": "^2.0.1",
+        "@smithy/types": "^2.0.2",
+        "@smithy/url-parser": "^2.0.1",
+        "@smithy/util-base64": "^2.0.0",
+        "@smithy/util-body-length-browser": "^2.0.0",
+        "@smithy/util-body-length-node": "^2.0.0",
+        "@smithy/util-defaults-mode-browser": "^2.0.1",
+        "@smithy/util-defaults-mode-node": "^2.0.1",
+        "@smithy/util-retry": "^2.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-network-firewall/node_modules/@aws-sdk/client-sts": {
+      "version": "3.386.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.386.0.tgz",
+      "integrity": "sha512-VK+tdZaI971IDP/1WqpYNorf+Q5uoJTqcp3y/bQY4Hr5bf8N3aztDrX7a2GaA07zgSdUa82VkScMKzW31jhsxw==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/credential-provider-node": "3.386.0",
+        "@aws-sdk/middleware-host-header": "3.379.1",
+        "@aws-sdk/middleware-logger": "3.378.0",
+        "@aws-sdk/middleware-recursion-detection": "3.378.0",
+        "@aws-sdk/middleware-sdk-sts": "3.379.1",
+        "@aws-sdk/middleware-signing": "3.379.1",
+        "@aws-sdk/middleware-user-agent": "3.386.0",
+        "@aws-sdk/types": "3.378.0",
+        "@aws-sdk/util-endpoints": "3.386.0",
+        "@aws-sdk/util-user-agent-browser": "3.378.0",
+        "@aws-sdk/util-user-agent-node": "3.378.0",
+        "@smithy/config-resolver": "^2.0.1",
+        "@smithy/fetch-http-handler": "^2.0.1",
+        "@smithy/hash-node": "^2.0.1",
+        "@smithy/invalid-dependency": "^2.0.1",
+        "@smithy/middleware-content-length": "^2.0.1",
+        "@smithy/middleware-endpoint": "^2.0.1",
+        "@smithy/middleware-retry": "^2.0.1",
+        "@smithy/middleware-serde": "^2.0.1",
+        "@smithy/middleware-stack": "^2.0.0",
+        "@smithy/node-config-provider": "^2.0.1",
+        "@smithy/node-http-handler": "^2.0.1",
+        "@smithy/protocol-http": "^2.0.1",
+        "@smithy/smithy-client": "^2.0.1",
+        "@smithy/types": "^2.0.2",
+        "@smithy/url-parser": "^2.0.1",
+        "@smithy/util-base64": "^2.0.0",
+        "@smithy/util-body-length-browser": "^2.0.0",
+        "@smithy/util-body-length-node": "^2.0.0",
+        "@smithy/util-defaults-mode-browser": "^2.0.1",
+        "@smithy/util-defaults-mode-node": "^2.0.1",
+        "@smithy/util-retry": "^2.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "fast-xml-parser": "4.2.5",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-network-firewall/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.378.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.378.0.tgz",
+      "integrity": "sha512-B2OVdO9kBClDwGgWTBLAQwFV8qYTYGyVujg++1FZFSFMt8ORFdZ5fNpErvJtiSjYiOOQMzyBeSNhKyYNXCiJjQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.378.0",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/types": "^2.0.2",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-network-firewall/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.386.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.386.0.tgz",
+      "integrity": "sha512-TDeOFwCq6Ri58OP4CvVIAbc+iJPld7TpOFB+YYQ+q0ut+92zaVTNrNoWZkygPCXKmeHUGZcwC9Mjt/4L+fBAkg==",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.378.0",
+        "@aws-sdk/credential-provider-process": "3.378.0",
+        "@aws-sdk/credential-provider-sso": "3.386.0",
+        "@aws-sdk/credential-provider-web-identity": "3.378.0",
+        "@aws-sdk/types": "3.378.0",
+        "@smithy/credential-provider-imds": "^2.0.0",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/shared-ini-file-loader": "^2.0.0",
+        "@smithy/types": "^2.0.2",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-network-firewall/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.386.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.386.0.tgz",
+      "integrity": "sha512-dvYSN+T1B96TqiZE5tBV8bHCNU6TKq5meeI06AdClHz3VPvPKDN/EL0undXpl/GnlvuhKUftmVwdUBefG3otZA==",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.378.0",
+        "@aws-sdk/credential-provider-ini": "3.386.0",
+        "@aws-sdk/credential-provider-process": "3.378.0",
+        "@aws-sdk/credential-provider-sso": "3.386.0",
+        "@aws-sdk/credential-provider-web-identity": "3.378.0",
+        "@aws-sdk/types": "3.378.0",
+        "@smithy/credential-provider-imds": "^2.0.0",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/shared-ini-file-loader": "^2.0.0",
+        "@smithy/types": "^2.0.2",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-network-firewall/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.378.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.378.0.tgz",
+      "integrity": "sha512-KFTIy7u+wXj3eDua4rgS0tODzMnXtXhAm1RxzCW9FL5JLBBrd82ymCj1Dp72217Sw5Do6NjCnDTTNkCHZMA77w==",
+      "dependencies": {
+        "@aws-sdk/types": "3.378.0",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/shared-ini-file-loader": "^2.0.0",
+        "@smithy/types": "^2.0.2",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-network-firewall/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.386.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.386.0.tgz",
+      "integrity": "sha512-7PvtrxMFpphQP8D5Zu5WpqZ/p7FBWiOQ2UQhzGKEry/9JIyTKiIZWsCu7OIWcfEx8RqSnLu3pDydc6HSTNs+lw==",
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.386.0",
+        "@aws-sdk/token-providers": "3.386.0",
+        "@aws-sdk/types": "3.378.0",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/shared-ini-file-loader": "^2.0.0",
+        "@smithy/types": "^2.0.2",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-network-firewall/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.378.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.378.0.tgz",
+      "integrity": "sha512-GWjydOszhc4xDF8xuPtBvboglXQr0gwCW1oHAvmLcOT38+Hd6qnKywnMSeoXYRPgoKfF9TkWQgW1jxplzCG0UA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.378.0",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/types": "^2.0.2",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-network-firewall/node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.379.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.379.1.tgz",
+      "integrity": "sha512-LI4KpAFWNWVr2aH2vRVblr0Y8tvDz23lj8LOmbDmCrzd5M21nxuocI/8nEAQj55LiTIf9Zs+dHCdsyegnFXdrA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.378.0",
+        "@smithy/protocol-http": "^2.0.1",
+        "@smithy/types": "^2.0.2",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-network-firewall/node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.378.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.378.0.tgz",
+      "integrity": "sha512-l1DyaDLm3KeBMNMuANI3scWh8Xvu248x+vw6Z7ExWOhGXFmQ1MW7YvASg/SdxWkhlF9HmkkTif1LdMB22x6QDA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.378.0",
+        "@smithy/types": "^2.0.2",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-network-firewall/node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.378.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.378.0.tgz",
+      "integrity": "sha512-mUMfHAz0oGNIWiTZHTVJb+I515Hqs2zx1j36Le4MMiiaMkPW1SRUF1FIwGuc1wh6E8jB5q+XfEMriDjRi4TZRA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.378.0",
+        "@smithy/protocol-http": "^2.0.1",
+        "@smithy/types": "^2.0.2",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-network-firewall/node_modules/@aws-sdk/middleware-sdk-sts": {
+      "version": "3.379.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.379.1.tgz",
+      "integrity": "sha512-SK3gSyT0XbLiY12+AjLFYL9YngxOXHnZF3Z33Cdd4a+AUYrVBV7JBEEGD1Nlwrcmko+3XgaKlmgUaR5s91MYvg==",
+      "dependencies": {
+        "@aws-sdk/middleware-signing": "3.379.1",
+        "@aws-sdk/types": "3.378.0",
+        "@smithy/types": "^2.0.2",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-network-firewall/node_modules/@aws-sdk/middleware-signing": {
+      "version": "3.379.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.379.1.tgz",
+      "integrity": "sha512-kBk2ZUvR84EM4fICjr8K+Ykpf8SI1UzzPp2/UVYZ0X+4H/ZCjfSqohGRwHykMqeplne9qHSL7/rGJs1H3l3gPg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.378.0",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/protocol-http": "^2.0.1",
+        "@smithy/signature-v4": "^2.0.0",
+        "@smithy/types": "^2.0.2",
+        "@smithy/util-middleware": "^2.0.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-network-firewall/node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.386.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.386.0.tgz",
+      "integrity": "sha512-h6nVr5dvzrSLM+5BGbyqISh1p2NoTNv0+IZkMcGyig2jpdhbkMOPvvoOGMg16/cmelUQCguT26Jr7WYpLFDsTg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.378.0",
+        "@aws-sdk/util-endpoints": "3.386.0",
+        "@smithy/protocol-http": "^2.0.1",
+        "@smithy/types": "^2.0.2",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-network-firewall/node_modules/@aws-sdk/token-providers": {
+      "version": "3.386.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.386.0.tgz",
+      "integrity": "sha512-DStdqBtpO0FRC4mDCIPtrpLCFMnYJFo4cYlUyr9CKvKvh2IzPMU4rsKQjUhtmzdjLEvPTAcdfRx2Q9/sJkfe9Q==",
+      "dependencies": {
+        "@aws-sdk/types": "3.378.0",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/shared-ini-file-loader": "^2.0.0",
+        "@smithy/types": "^2.0.2",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-network-firewall/node_modules/@aws-sdk/types": {
+      "version": "3.378.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.378.0.tgz",
+      "integrity": "sha512-qP0CvR/ItgktmN8YXpGQglzzR/6s0nrsQ4zIfx3HMwpsBTwuouYahcCtF1Vr82P4NFcoDA412EJahJ2pIqEd+w==",
+      "dependencies": {
+        "@smithy/types": "^2.0.2",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-network-firewall/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.386.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.386.0.tgz",
+      "integrity": "sha512-FDQRC9f78Kx12KsR43MukLRfqF3BNz5VfFdKP9ZYx3KK+bMjU1czjmjOS8bNMJWYM1Sn+nobBpPS3e2uupBtpg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.378.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-network-firewall/node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.378.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.378.0.tgz",
+      "integrity": "sha512-FSCpagzftK1W+m7Ar6lpX7/Gr9y5P56nhFYz8U4EYQ4PkufS6czWX9YW+/FA5OYV0vlQ/SvPqMnzoHIPUNhZrQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.378.0",
+        "@smithy/types": "^2.0.2",
+        "bowser": "^2.11.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-network-firewall/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.378.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.378.0.tgz",
+      "integrity": "sha512-IdwVJV0E96MkJeFte4dlWqvB+oiqCiZ5lOlheY3W9NynTuuX0GGYNC8Y9yIsV8Oava1+ujpJq0ww6qXdYxmO4A==",
+      "dependencies": {
+        "@aws-sdk/types": "3.378.0",
+        "@smithy/node-config-provider": "^2.0.1",
+        "@smithy/types": "^2.0.2",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/client-network-firewall/node_modules/@smithy/protocol-http": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-2.0.2.tgz",
+      "integrity": "sha512-qWu8g1FUy+m36KpO1sREJSF7BaLmjw9AqOuwxLVVSdYz+nUQjc9tFAZ9LB6jJXKdsZFSjfkjHJBbhD78QdE7Rw==",
+      "dependencies": {
+        "@smithy/types": "^2.1.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-network-firewall/node_modules/@smithy/types": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.1.0.tgz",
+      "integrity": "sha512-KLsCsqxX0j2l99iP8s0f7LBlcsp7a7ceXGn0LPYPyVOsqmIKvSaPQajq0YevlL4T9Bm+DtcyXfBTbtBcLX1I7A==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@aws-sdk/client-opensearch": {
       "version": "3.359.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-opensearch/-/client-opensearch-3.359.0.tgz",
@@ -4124,6 +4544,415 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@smithy/abort-controller": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.0.2.tgz",
+      "integrity": "sha512-ln5Cob0mksym62sLr7NiPOSqJ0jKao4qjfcNLDdgINM1lQI12hXrZBlKdPHbXJqpKhKiECDgonMoqCM8bigq4g==",
+      "dependencies": {
+        "@smithy/types": "^2.1.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/abort-controller/node_modules/@smithy/types": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.1.0.tgz",
+      "integrity": "sha512-KLsCsqxX0j2l99iP8s0f7LBlcsp7a7ceXGn0LPYPyVOsqmIKvSaPQajq0YevlL4T9Bm+DtcyXfBTbtBcLX1I7A==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/config-resolver": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-2.0.2.tgz",
+      "integrity": "sha512-0kdsqBL6BdmSbdU6YaDkodVBMua5MuQQluC3nocJ7OJ6PnOuM7i2FEQHE46LBadLqT+CimlDSM+6j91uHNL1ng==",
+      "dependencies": {
+        "@smithy/types": "^2.1.0",
+        "@smithy/util-config-provider": "^2.0.0",
+        "@smithy/util-middleware": "^2.0.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/config-resolver/node_modules/@smithy/types": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.1.0.tgz",
+      "integrity": "sha512-KLsCsqxX0j2l99iP8s0f7LBlcsp7a7ceXGn0LPYPyVOsqmIKvSaPQajq0YevlL4T9Bm+DtcyXfBTbtBcLX1I7A==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-2.0.2.tgz",
+      "integrity": "sha512-mbWFYEZ00LBRDk3WvcXViwpdpkJQcfrM3seuKzFxZnF6wIBLMwrcWcsj+OUC/1L+86m8aQY9imXMAaQsAoGxow==",
+      "dependencies": {
+        "@smithy/node-config-provider": "^2.0.2",
+        "@smithy/property-provider": "^2.0.2",
+        "@smithy/types": "^2.1.0",
+        "@smithy/url-parser": "^2.0.2",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds/node_modules/@smithy/types": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.1.0.tgz",
+      "integrity": "sha512-KLsCsqxX0j2l99iP8s0f7LBlcsp7a7ceXGn0LPYPyVOsqmIKvSaPQajq0YevlL4T9Bm+DtcyXfBTbtBcLX1I7A==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-codec": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-2.0.2.tgz",
+      "integrity": "sha512-PQZiKx7fMnNwx4zxcUCm82VjnqK6wV4MEHSmMy3taj5dKfXV782IjRGyaDT+8TsmNqVdZIkve5zLRAzh+7kOhA==",
+      "dependencies": {
+        "@aws-crypto/crc32": "3.0.0",
+        "@smithy/types": "^2.1.0",
+        "@smithy/util-hex-encoding": "^2.0.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-codec/node_modules/@smithy/types": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.1.0.tgz",
+      "integrity": "sha512-KLsCsqxX0j2l99iP8s0f7LBlcsp7a7ceXGn0LPYPyVOsqmIKvSaPQajq0YevlL4T9Bm+DtcyXfBTbtBcLX1I7A==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-2.0.2.tgz",
+      "integrity": "sha512-Wo2m1RaiXNSLF4J3D62LpdSoj/YYb+6tn0H8is1tSrzr7eXAdiYVBc0wIa23N0wT4zmN0iG/yNY6gTCDQ6799A==",
+      "dependencies": {
+        "@smithy/protocol-http": "^2.0.2",
+        "@smithy/querystring-builder": "^2.0.2",
+        "@smithy/types": "^2.1.0",
+        "@smithy/util-base64": "^2.0.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler/node_modules/@smithy/protocol-http": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-2.0.2.tgz",
+      "integrity": "sha512-qWu8g1FUy+m36KpO1sREJSF7BaLmjw9AqOuwxLVVSdYz+nUQjc9tFAZ9LB6jJXKdsZFSjfkjHJBbhD78QdE7Rw==",
+      "dependencies": {
+        "@smithy/types": "^2.1.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler/node_modules/@smithy/types": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.1.0.tgz",
+      "integrity": "sha512-KLsCsqxX0j2l99iP8s0f7LBlcsp7a7ceXGn0LPYPyVOsqmIKvSaPQajq0YevlL4T9Bm+DtcyXfBTbtBcLX1I7A==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/hash-node": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-2.0.2.tgz",
+      "integrity": "sha512-JKDzZ1YVR7JzOBaJoWy3ToJCE86OQE6D4kOBvvVsu93a3lcF9kv6KYTKBYEWAjwOn/CpK4NH7mKB01OQ8H+aiA==",
+      "dependencies": {
+        "@smithy/types": "^2.1.0",
+        "@smithy/util-buffer-from": "^2.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/hash-node/node_modules/@smithy/types": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.1.0.tgz",
+      "integrity": "sha512-KLsCsqxX0j2l99iP8s0f7LBlcsp7a7ceXGn0LPYPyVOsqmIKvSaPQajq0YevlL4T9Bm+DtcyXfBTbtBcLX1I7A==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/invalid-dependency": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-2.0.2.tgz",
+      "integrity": "sha512-inQZQ5gCO3WRWuXpsc1YJ4KBjsvj2qsoU32yTIKznBWTCQe/D5Dp+sSaysqBqxe0VTZ+8nFEHdUMWUX2BxQThw==",
+      "dependencies": {
+        "@smithy/types": "^2.1.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@smithy/invalid-dependency/node_modules/@smithy/types": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.1.0.tgz",
+      "integrity": "sha512-KLsCsqxX0j2l99iP8s0f7LBlcsp7a7ceXGn0LPYPyVOsqmIKvSaPQajq0YevlL4T9Bm+DtcyXfBTbtBcLX1I7A==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/is-array-buffer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.0.0.tgz",
+      "integrity": "sha512-z3PjFjMyZNI98JFRJi/U0nGoLWMSJlDjAW4QUX2WNZLas5C0CmVV6LJ01JI0k90l7FvpmixjWxPFmENSClQ7ug==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-content-length": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-2.0.2.tgz",
+      "integrity": "sha512-FmHlNfuvYgDZE3fIx0G3rD/wLXfAmBYE4mVc/w6d7RllA7TygPzq2pfHL1iCMzWkWTdoAVnt3h4aavAZnhaxEQ==",
+      "dependencies": {
+        "@smithy/protocol-http": "^2.0.2",
+        "@smithy/types": "^2.1.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-content-length/node_modules/@smithy/protocol-http": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-2.0.2.tgz",
+      "integrity": "sha512-qWu8g1FUy+m36KpO1sREJSF7BaLmjw9AqOuwxLVVSdYz+nUQjc9tFAZ9LB6jJXKdsZFSjfkjHJBbhD78QdE7Rw==",
+      "dependencies": {
+        "@smithy/types": "^2.1.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-content-length/node_modules/@smithy/types": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.1.0.tgz",
+      "integrity": "sha512-KLsCsqxX0j2l99iP8s0f7LBlcsp7a7ceXGn0LPYPyVOsqmIKvSaPQajq0YevlL4T9Bm+DtcyXfBTbtBcLX1I7A==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-endpoint": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-2.0.2.tgz",
+      "integrity": "sha512-ropE7/c+g22QeluZ+By/B/WvVep0UFreX+IeRMGIO7EbOUPgqtJRXpbJFdG6JKB1uC+CdaJLn4MnZnVBpcyjuA==",
+      "dependencies": {
+        "@smithy/middleware-serde": "^2.0.2",
+        "@smithy/types": "^2.1.0",
+        "@smithy/url-parser": "^2.0.2",
+        "@smithy/util-middleware": "^2.0.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-endpoint/node_modules/@smithy/types": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.1.0.tgz",
+      "integrity": "sha512-KLsCsqxX0j2l99iP8s0f7LBlcsp7a7ceXGn0LPYPyVOsqmIKvSaPQajq0YevlL4T9Bm+DtcyXfBTbtBcLX1I7A==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-retry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-2.0.2.tgz",
+      "integrity": "sha512-wtBUXqtZVriiXppYaFkUrybAPhFVX7vebnW/yVPliLMWMcguOMS58qhOYPZe3t9Wki2+mASfyu+kO3An8lAg2A==",
+      "dependencies": {
+        "@smithy/protocol-http": "^2.0.2",
+        "@smithy/service-error-classification": "^2.0.0",
+        "@smithy/types": "^2.1.0",
+        "@smithy/util-middleware": "^2.0.0",
+        "@smithy/util-retry": "^2.0.0",
+        "tslib": "^2.5.0",
+        "uuid": "^8.3.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-retry/node_modules/@smithy/protocol-http": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-2.0.2.tgz",
+      "integrity": "sha512-qWu8g1FUy+m36KpO1sREJSF7BaLmjw9AqOuwxLVVSdYz+nUQjc9tFAZ9LB6jJXKdsZFSjfkjHJBbhD78QdE7Rw==",
+      "dependencies": {
+        "@smithy/types": "^2.1.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-retry/node_modules/@smithy/types": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.1.0.tgz",
+      "integrity": "sha512-KLsCsqxX0j2l99iP8s0f7LBlcsp7a7ceXGn0LPYPyVOsqmIKvSaPQajq0YevlL4T9Bm+DtcyXfBTbtBcLX1I7A==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-serde": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-2.0.2.tgz",
+      "integrity": "sha512-Kw9xLdlueIaivUWslKB67WZ/cCUg3QnzYVIA3t5KfgsseEEuU4UxXw8NSTvIt71gqQloY+Um8ugS+idgxrWWnw==",
+      "dependencies": {
+        "@smithy/types": "^2.1.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-serde/node_modules/@smithy/types": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.1.0.tgz",
+      "integrity": "sha512-KLsCsqxX0j2l99iP8s0f7LBlcsp7a7ceXGn0LPYPyVOsqmIKvSaPQajq0YevlL4T9Bm+DtcyXfBTbtBcLX1I7A==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-stack": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-2.0.0.tgz",
+      "integrity": "sha512-31XC1xNF65nlbc16yuh3wwTudmqs6qy4EseQUGF8A/p2m/5wdd/cnXJqpniy/XvXVwkHPz/GwV36HqzHtIKATQ==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/node-config-provider": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-2.0.2.tgz",
+      "integrity": "sha512-9wVJccASfuCctNWrzR0zrDkf0ox3HCHGEhFlWL2LBoghUYuK28pVRBbG69wvnkhlHnB8dDZHagxH+Nq9dm7eWw==",
+      "dependencies": {
+        "@smithy/property-provider": "^2.0.2",
+        "@smithy/shared-ini-file-loader": "^2.0.2",
+        "@smithy/types": "^2.1.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/node-config-provider/node_modules/@smithy/types": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.1.0.tgz",
+      "integrity": "sha512-KLsCsqxX0j2l99iP8s0f7LBlcsp7a7ceXGn0LPYPyVOsqmIKvSaPQajq0YevlL4T9Bm+DtcyXfBTbtBcLX1I7A==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-2.0.2.tgz",
+      "integrity": "sha512-lpZjmtmyZqSAtMPsbrLhb7XoAQ2kAHeuLY/csW6I2k+QyFvOk7cZeQsqEngWmZ9SJaeYiDCBINxAIM61i5WGLw==",
+      "dependencies": {
+        "@smithy/abort-controller": "^2.0.2",
+        "@smithy/protocol-http": "^2.0.2",
+        "@smithy/querystring-builder": "^2.0.2",
+        "@smithy/types": "^2.1.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler/node_modules/@smithy/protocol-http": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-2.0.2.tgz",
+      "integrity": "sha512-qWu8g1FUy+m36KpO1sREJSF7BaLmjw9AqOuwxLVVSdYz+nUQjc9tFAZ9LB6jJXKdsZFSjfkjHJBbhD78QdE7Rw==",
+      "dependencies": {
+        "@smithy/types": "^2.1.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler/node_modules/@smithy/types": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.1.0.tgz",
+      "integrity": "sha512-KLsCsqxX0j2l99iP8s0f7LBlcsp7a7ceXGn0LPYPyVOsqmIKvSaPQajq0YevlL4T9Bm+DtcyXfBTbtBcLX1I7A==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/property-provider": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.0.2.tgz",
+      "integrity": "sha512-DfaZ8cO+d/mgnMzIllcXcU4OYP+omiOl2LYdn/fTGpw/EAQSVzscYV2muV3sDDnuPYQ/r014hUqIxnF+pzh+SQ==",
+      "dependencies": {
+        "@smithy/types": "^2.1.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/property-provider/node_modules/@smithy/types": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.1.0.tgz",
+      "integrity": "sha512-KLsCsqxX0j2l99iP8s0f7LBlcsp7a7ceXGn0LPYPyVOsqmIKvSaPQajq0YevlL4T9Bm+DtcyXfBTbtBcLX1I7A==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@smithy/protocol-http": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-1.0.1.tgz",
@@ -4136,11 +4965,356 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@smithy/querystring-builder": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-2.0.2.tgz",
+      "integrity": "sha512-H99LOMWEssfwqkOoTs4Y12UiZ7CTGQSX5Nrx5UkYgRbUEpC1GnnaprHiYrqclC58/xr4K76aNchdPyioxewMzA==",
+      "dependencies": {
+        "@smithy/types": "^2.1.0",
+        "@smithy/util-uri-escape": "^2.0.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/querystring-builder/node_modules/@smithy/types": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.1.0.tgz",
+      "integrity": "sha512-KLsCsqxX0j2l99iP8s0f7LBlcsp7a7ceXGn0LPYPyVOsqmIKvSaPQajq0YevlL4T9Bm+DtcyXfBTbtBcLX1I7A==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/querystring-parser": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-2.0.2.tgz",
+      "integrity": "sha512-L4VtKQ8O4/aWPQJbiFymbhAmxdfLnEaROh/Vs0OstJ7jtOZeBl2QJmuWY2V7hjt64W7V+tEn2sv6vVvnxkm/xQ==",
+      "dependencies": {
+        "@smithy/types": "^2.1.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/querystring-parser/node_modules/@smithy/types": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.1.0.tgz",
+      "integrity": "sha512-KLsCsqxX0j2l99iP8s0f7LBlcsp7a7ceXGn0LPYPyVOsqmIKvSaPQajq0YevlL4T9Bm+DtcyXfBTbtBcLX1I7A==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/service-error-classification": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-2.0.0.tgz",
+      "integrity": "sha512-2z5Nafy1O0cTf69wKyNjGW/sNVMiqDnb4jgwfMG8ye8KnFJ5qmJpDccwIbJNhXIfbsxTg9SEec2oe1cexhMJvw==",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/shared-ini-file-loader": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.0.2.tgz",
+      "integrity": "sha512-2VkNOM/82u4vatVdK5nfusgGIlvR48Fkq6me17Oc+V1iyxfR/1x0pG6LzW0br1qlGtzBYFZKmDyviBRcPVFTVw==",
+      "dependencies": {
+        "@smithy/types": "^2.1.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/shared-ini-file-loader/node_modules/@smithy/types": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.1.0.tgz",
+      "integrity": "sha512-KLsCsqxX0j2l99iP8s0f7LBlcsp7a7ceXGn0LPYPyVOsqmIKvSaPQajq0YevlL4T9Bm+DtcyXfBTbtBcLX1I7A==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-2.0.2.tgz",
+      "integrity": "sha512-YMooDEw/UmGxcXY4qWnSXkbPFsRloluSvyXVT678YPDN/K2AS1GzKfRsvSU7fbccOB4WF8MHZf2UqcRGEltE3Q==",
+      "dependencies": {
+        "@smithy/eventstream-codec": "^2.0.2",
+        "@smithy/is-array-buffer": "^2.0.0",
+        "@smithy/types": "^2.1.0",
+        "@smithy/util-hex-encoding": "^2.0.0",
+        "@smithy/util-middleware": "^2.0.0",
+        "@smithy/util-uri-escape": "^2.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4/node_modules/@smithy/types": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.1.0.tgz",
+      "integrity": "sha512-KLsCsqxX0j2l99iP8s0f7LBlcsp7a7ceXGn0LPYPyVOsqmIKvSaPQajq0YevlL4T9Bm+DtcyXfBTbtBcLX1I7A==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/smithy-client": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-2.0.2.tgz",
+      "integrity": "sha512-mDfokI8WwLU5C0gcQ4ww/zJI/WLGSh2+vdIA42JRnjfYUjJNH/rKfX9YOnn2eBOxl3loATERVUqkHmKe+P8s2Q==",
+      "dependencies": {
+        "@smithy/middleware-stack": "^2.0.0",
+        "@smithy/types": "^2.1.0",
+        "@smithy/util-stream": "^2.0.2",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/smithy-client/node_modules/@smithy/types": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.1.0.tgz",
+      "integrity": "sha512-KLsCsqxX0j2l99iP8s0f7LBlcsp7a7ceXGn0LPYPyVOsqmIKvSaPQajq0YevlL4T9Bm+DtcyXfBTbtBcLX1I7A==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@smithy/types": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.0.0.tgz",
       "integrity": "sha512-kc1m5wPBHQCTixwuaOh9vnak/iJm21DrSf9UK6yDE5S3mQQ4u11pqAUiKWnlrZnYkeLfAI9UEHj9OaMT1v5Umg==",
       "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/url-parser": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-2.0.2.tgz",
+      "integrity": "sha512-X1mHCzrSVDlhVy7d3S7Vq+dTfYzwh4n7xGHhyJumu77nJqIss0lazVug85Pwo0DKIoO314wAOvMnBxNYDa+7wA==",
+      "dependencies": {
+        "@smithy/querystring-parser": "^2.0.2",
+        "@smithy/types": "^2.1.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@smithy/url-parser/node_modules/@smithy/types": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.1.0.tgz",
+      "integrity": "sha512-KLsCsqxX0j2l99iP8s0f7LBlcsp7a7ceXGn0LPYPyVOsqmIKvSaPQajq0YevlL4T9Bm+DtcyXfBTbtBcLX1I7A==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-base64": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-2.0.0.tgz",
+      "integrity": "sha512-Zb1E4xx+m5Lud8bbeYi5FkcMJMnn+1WUnJF3qD7rAdXpaL7UjkFQLdmW5fHadoKbdHpwH9vSR8EyTJFHJs++tA==",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.0.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-body-length-browser": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-2.0.0.tgz",
+      "integrity": "sha512-JdDuS4ircJt+FDnaQj88TzZY3+njZ6O+D3uakS32f2VNnDo3vyEuNdBOh/oFd8Df1zSZOuH1HEChk2AOYDezZg==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@smithy/util-body-length-node": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-2.0.0.tgz",
+      "integrity": "sha512-ZV7Z/WHTMxHJe/xL/56qZwSUcl63/5aaPAGjkfynJm4poILjdD4GmFI+V+YWabh2WJIjwTKZ5PNsuvPQKt93Mg==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-buffer-from": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.0.0.tgz",
+      "integrity": "sha512-/YNnLoHsR+4W4Vf2wL5lGv0ksg8Bmk3GEGxn2vEQt52AQaPSCuaO5PM5VM7lP1K9qHRKHwrPGktqVoAHKWHxzw==",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.0.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-config-provider": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-2.0.0.tgz",
+      "integrity": "sha512-xCQ6UapcIWKxXHEU4Mcs2s7LcFQRiU3XEluM2WcCjjBtQkUN71Tb+ydGmJFPxMUrW/GWMgQEEGipLym4XG0jZg==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-defaults-mode-browser": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-2.0.2.tgz",
+      "integrity": "sha512-c2tMMjb624XLuzmlRoZpnFOkejVxcgw3WQKdmgdGZYZapcLzXyC0H9JhnXMjQCt30GqLTlsILRNVBYwFRbw/4Q==",
+      "dependencies": {
+        "@smithy/property-provider": "^2.0.2",
+        "@smithy/types": "^2.1.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@smithy/util-defaults-mode-browser/node_modules/@smithy/types": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.1.0.tgz",
+      "integrity": "sha512-KLsCsqxX0j2l99iP8s0f7LBlcsp7a7ceXGn0LPYPyVOsqmIKvSaPQajq0YevlL4T9Bm+DtcyXfBTbtBcLX1I7A==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-defaults-mode-node": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-2.0.2.tgz",
+      "integrity": "sha512-gt7m5LLqUtEKldJLyc14DE4kb85vxwomvt9AfEMEvWM4VwfWS1kGJqiStZFb5KNqnQPXw8vvpgLTi8NrWAOXqg==",
+      "dependencies": {
+        "@smithy/config-resolver": "^2.0.2",
+        "@smithy/credential-provider-imds": "^2.0.2",
+        "@smithy/node-config-provider": "^2.0.2",
+        "@smithy/property-provider": "^2.0.2",
+        "@smithy/types": "^2.1.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@smithy/util-defaults-mode-node/node_modules/@smithy/types": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.1.0.tgz",
+      "integrity": "sha512-KLsCsqxX0j2l99iP8s0f7LBlcsp7a7ceXGn0LPYPyVOsqmIKvSaPQajq0YevlL4T9Bm+DtcyXfBTbtBcLX1I7A==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-hex-encoding": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-2.0.0.tgz",
+      "integrity": "sha512-c5xY+NUnFqG6d7HFh1IFfrm3mGl29lC+vF+geHv4ToiuJCBmIfzx6IeHLg+OgRdPFKDXIw6pvi+p3CsscaMcMA==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-middleware": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-2.0.0.tgz",
+      "integrity": "sha512-eCWX4ECuDHn1wuyyDdGdUWnT4OGyIzV0LN1xRttBFMPI9Ff/4heSHVxneyiMtOB//zpXWCha1/SWHJOZstG7kA==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-retry": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-2.0.0.tgz",
+      "integrity": "sha512-/dvJ8afrElasuiiIttRJeoS2sy8YXpksQwiM/TcepqdRVp7u4ejd9C4IQURHNjlfPUT7Y6lCDSa2zQJbdHhVTg==",
+      "dependencies": {
+        "@smithy/service-error-classification": "^2.0.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-stream": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-2.0.2.tgz",
+      "integrity": "sha512-Mg9IJcKIu4YKlbzvpp1KLvh4JZLdcPgpxk+LICuDwzZCfxe47R9enVK8dNEiuyiIGK2ExbfvzCVT8IBru62vZw==",
+      "dependencies": {
+        "@smithy/fetch-http-handler": "^2.0.2",
+        "@smithy/node-http-handler": "^2.0.2",
+        "@smithy/types": "^2.1.0",
+        "@smithy/util-base64": "^2.0.0",
+        "@smithy/util-buffer-from": "^2.0.0",
+        "@smithy/util-hex-encoding": "^2.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-stream/node_modules/@smithy/types": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.1.0.tgz",
+      "integrity": "sha512-KLsCsqxX0j2l99iP8s0f7LBlcsp7a7ceXGn0LPYPyVOsqmIKvSaPQajq0YevlL4T9Bm+DtcyXfBTbtBcLX1I7A==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-uri-escape": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-2.0.0.tgz",
+      "integrity": "sha512-ebkxsqinSdEooQduuk9CbKcI+wheijxEb3utGXkCoYQkJnwTnLbH1JXGimJtUkQwNQbsbuYwG2+aFVyZf5TLaw==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-utf8": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.0.0.tgz",
+      "integrity": "sha512-rctU1VkziY84n5OXe3bPNpKR001ZCME2JCaBBFgtiM2hfKbHFudc/BkMuPab8hRbLd0j3vbnBTTZ1igBf0wgiQ==",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.0.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -6319,6 +7493,356 @@
         "tslib": "^2.5.0"
       }
     },
+    "@aws-sdk/client-network-firewall": {
+      "version": "3.386.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-network-firewall/-/client-network-firewall-3.386.0.tgz",
+      "integrity": "sha512-kU95pDg6XDBJC2i1UzipdmLEV7bTn8+BdfMFbBykP8JK7ydEGh0oJeicydC79K6+d2gVajZxykfuzmmLLLhVdQ==",
+      "requires": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/client-sts": "3.386.0",
+        "@aws-sdk/credential-provider-node": "3.386.0",
+        "@aws-sdk/middleware-host-header": "3.379.1",
+        "@aws-sdk/middleware-logger": "3.378.0",
+        "@aws-sdk/middleware-recursion-detection": "3.378.0",
+        "@aws-sdk/middleware-signing": "3.379.1",
+        "@aws-sdk/middleware-user-agent": "3.386.0",
+        "@aws-sdk/types": "3.378.0",
+        "@aws-sdk/util-endpoints": "3.386.0",
+        "@aws-sdk/util-user-agent-browser": "3.378.0",
+        "@aws-sdk/util-user-agent-node": "3.378.0",
+        "@smithy/config-resolver": "^2.0.1",
+        "@smithy/fetch-http-handler": "^2.0.1",
+        "@smithy/hash-node": "^2.0.1",
+        "@smithy/invalid-dependency": "^2.0.1",
+        "@smithy/middleware-content-length": "^2.0.1",
+        "@smithy/middleware-endpoint": "^2.0.1",
+        "@smithy/middleware-retry": "^2.0.1",
+        "@smithy/middleware-serde": "^2.0.1",
+        "@smithy/middleware-stack": "^2.0.0",
+        "@smithy/node-config-provider": "^2.0.1",
+        "@smithy/node-http-handler": "^2.0.1",
+        "@smithy/protocol-http": "^2.0.1",
+        "@smithy/smithy-client": "^2.0.1",
+        "@smithy/types": "^2.0.2",
+        "@smithy/url-parser": "^2.0.1",
+        "@smithy/util-base64": "^2.0.0",
+        "@smithy/util-body-length-browser": "^2.0.0",
+        "@smithy/util-body-length-node": "^2.0.0",
+        "@smithy/util-defaults-mode-browser": "^2.0.1",
+        "@smithy/util-defaults-mode-node": "^2.0.1",
+        "@smithy/util-retry": "^2.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "@aws-sdk/client-sso": {
+          "version": "3.386.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.386.0.tgz",
+          "integrity": "sha512-UBgRo0q/XSle9CHCpoFhzq9wCfdc4kJw40cpPoHJPbb5m3JMcDu0mq4LTY7Nwnoy9jBThfRVYf3EF2BMF8fo6A==",
+          "requires": {
+            "@aws-crypto/sha256-browser": "3.0.0",
+            "@aws-crypto/sha256-js": "3.0.0",
+            "@aws-sdk/middleware-host-header": "3.379.1",
+            "@aws-sdk/middleware-logger": "3.378.0",
+            "@aws-sdk/middleware-recursion-detection": "3.378.0",
+            "@aws-sdk/middleware-user-agent": "3.386.0",
+            "@aws-sdk/types": "3.378.0",
+            "@aws-sdk/util-endpoints": "3.386.0",
+            "@aws-sdk/util-user-agent-browser": "3.378.0",
+            "@aws-sdk/util-user-agent-node": "3.378.0",
+            "@smithy/config-resolver": "^2.0.1",
+            "@smithy/fetch-http-handler": "^2.0.1",
+            "@smithy/hash-node": "^2.0.1",
+            "@smithy/invalid-dependency": "^2.0.1",
+            "@smithy/middleware-content-length": "^2.0.1",
+            "@smithy/middleware-endpoint": "^2.0.1",
+            "@smithy/middleware-retry": "^2.0.1",
+            "@smithy/middleware-serde": "^2.0.1",
+            "@smithy/middleware-stack": "^2.0.0",
+            "@smithy/node-config-provider": "^2.0.1",
+            "@smithy/node-http-handler": "^2.0.1",
+            "@smithy/protocol-http": "^2.0.1",
+            "@smithy/smithy-client": "^2.0.1",
+            "@smithy/types": "^2.0.2",
+            "@smithy/url-parser": "^2.0.1",
+            "@smithy/util-base64": "^2.0.0",
+            "@smithy/util-body-length-browser": "^2.0.0",
+            "@smithy/util-body-length-node": "^2.0.0",
+            "@smithy/util-defaults-mode-browser": "^2.0.1",
+            "@smithy/util-defaults-mode-node": "^2.0.1",
+            "@smithy/util-retry": "^2.0.0",
+            "@smithy/util-utf8": "^2.0.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/client-sts": {
+          "version": "3.386.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.386.0.tgz",
+          "integrity": "sha512-VK+tdZaI971IDP/1WqpYNorf+Q5uoJTqcp3y/bQY4Hr5bf8N3aztDrX7a2GaA07zgSdUa82VkScMKzW31jhsxw==",
+          "requires": {
+            "@aws-crypto/sha256-browser": "3.0.0",
+            "@aws-crypto/sha256-js": "3.0.0",
+            "@aws-sdk/credential-provider-node": "3.386.0",
+            "@aws-sdk/middleware-host-header": "3.379.1",
+            "@aws-sdk/middleware-logger": "3.378.0",
+            "@aws-sdk/middleware-recursion-detection": "3.378.0",
+            "@aws-sdk/middleware-sdk-sts": "3.379.1",
+            "@aws-sdk/middleware-signing": "3.379.1",
+            "@aws-sdk/middleware-user-agent": "3.386.0",
+            "@aws-sdk/types": "3.378.0",
+            "@aws-sdk/util-endpoints": "3.386.0",
+            "@aws-sdk/util-user-agent-browser": "3.378.0",
+            "@aws-sdk/util-user-agent-node": "3.378.0",
+            "@smithy/config-resolver": "^2.0.1",
+            "@smithy/fetch-http-handler": "^2.0.1",
+            "@smithy/hash-node": "^2.0.1",
+            "@smithy/invalid-dependency": "^2.0.1",
+            "@smithy/middleware-content-length": "^2.0.1",
+            "@smithy/middleware-endpoint": "^2.0.1",
+            "@smithy/middleware-retry": "^2.0.1",
+            "@smithy/middleware-serde": "^2.0.1",
+            "@smithy/middleware-stack": "^2.0.0",
+            "@smithy/node-config-provider": "^2.0.1",
+            "@smithy/node-http-handler": "^2.0.1",
+            "@smithy/protocol-http": "^2.0.1",
+            "@smithy/smithy-client": "^2.0.1",
+            "@smithy/types": "^2.0.2",
+            "@smithy/url-parser": "^2.0.1",
+            "@smithy/util-base64": "^2.0.0",
+            "@smithy/util-body-length-browser": "^2.0.0",
+            "@smithy/util-body-length-node": "^2.0.0",
+            "@smithy/util-defaults-mode-browser": "^2.0.1",
+            "@smithy/util-defaults-mode-node": "^2.0.1",
+            "@smithy/util-retry": "^2.0.0",
+            "@smithy/util-utf8": "^2.0.0",
+            "fast-xml-parser": "4.2.5",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/credential-provider-env": {
+          "version": "3.378.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.378.0.tgz",
+          "integrity": "sha512-B2OVdO9kBClDwGgWTBLAQwFV8qYTYGyVujg++1FZFSFMt8ORFdZ5fNpErvJtiSjYiOOQMzyBeSNhKyYNXCiJjQ==",
+          "requires": {
+            "@aws-sdk/types": "3.378.0",
+            "@smithy/property-provider": "^2.0.0",
+            "@smithy/types": "^2.0.2",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/credential-provider-ini": {
+          "version": "3.386.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.386.0.tgz",
+          "integrity": "sha512-TDeOFwCq6Ri58OP4CvVIAbc+iJPld7TpOFB+YYQ+q0ut+92zaVTNrNoWZkygPCXKmeHUGZcwC9Mjt/4L+fBAkg==",
+          "requires": {
+            "@aws-sdk/credential-provider-env": "3.378.0",
+            "@aws-sdk/credential-provider-process": "3.378.0",
+            "@aws-sdk/credential-provider-sso": "3.386.0",
+            "@aws-sdk/credential-provider-web-identity": "3.378.0",
+            "@aws-sdk/types": "3.378.0",
+            "@smithy/credential-provider-imds": "^2.0.0",
+            "@smithy/property-provider": "^2.0.0",
+            "@smithy/shared-ini-file-loader": "^2.0.0",
+            "@smithy/types": "^2.0.2",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/credential-provider-node": {
+          "version": "3.386.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.386.0.tgz",
+          "integrity": "sha512-dvYSN+T1B96TqiZE5tBV8bHCNU6TKq5meeI06AdClHz3VPvPKDN/EL0undXpl/GnlvuhKUftmVwdUBefG3otZA==",
+          "requires": {
+            "@aws-sdk/credential-provider-env": "3.378.0",
+            "@aws-sdk/credential-provider-ini": "3.386.0",
+            "@aws-sdk/credential-provider-process": "3.378.0",
+            "@aws-sdk/credential-provider-sso": "3.386.0",
+            "@aws-sdk/credential-provider-web-identity": "3.378.0",
+            "@aws-sdk/types": "3.378.0",
+            "@smithy/credential-provider-imds": "^2.0.0",
+            "@smithy/property-provider": "^2.0.0",
+            "@smithy/shared-ini-file-loader": "^2.0.0",
+            "@smithy/types": "^2.0.2",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/credential-provider-process": {
+          "version": "3.378.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.378.0.tgz",
+          "integrity": "sha512-KFTIy7u+wXj3eDua4rgS0tODzMnXtXhAm1RxzCW9FL5JLBBrd82ymCj1Dp72217Sw5Do6NjCnDTTNkCHZMA77w==",
+          "requires": {
+            "@aws-sdk/types": "3.378.0",
+            "@smithy/property-provider": "^2.0.0",
+            "@smithy/shared-ini-file-loader": "^2.0.0",
+            "@smithy/types": "^2.0.2",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/credential-provider-sso": {
+          "version": "3.386.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.386.0.tgz",
+          "integrity": "sha512-7PvtrxMFpphQP8D5Zu5WpqZ/p7FBWiOQ2UQhzGKEry/9JIyTKiIZWsCu7OIWcfEx8RqSnLu3pDydc6HSTNs+lw==",
+          "requires": {
+            "@aws-sdk/client-sso": "3.386.0",
+            "@aws-sdk/token-providers": "3.386.0",
+            "@aws-sdk/types": "3.378.0",
+            "@smithy/property-provider": "^2.0.0",
+            "@smithy/shared-ini-file-loader": "^2.0.0",
+            "@smithy/types": "^2.0.2",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/credential-provider-web-identity": {
+          "version": "3.378.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.378.0.tgz",
+          "integrity": "sha512-GWjydOszhc4xDF8xuPtBvboglXQr0gwCW1oHAvmLcOT38+Hd6qnKywnMSeoXYRPgoKfF9TkWQgW1jxplzCG0UA==",
+          "requires": {
+            "@aws-sdk/types": "3.378.0",
+            "@smithy/property-provider": "^2.0.0",
+            "@smithy/types": "^2.0.2",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/middleware-host-header": {
+          "version": "3.379.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.379.1.tgz",
+          "integrity": "sha512-LI4KpAFWNWVr2aH2vRVblr0Y8tvDz23lj8LOmbDmCrzd5M21nxuocI/8nEAQj55LiTIf9Zs+dHCdsyegnFXdrA==",
+          "requires": {
+            "@aws-sdk/types": "3.378.0",
+            "@smithy/protocol-http": "^2.0.1",
+            "@smithy/types": "^2.0.2",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/middleware-logger": {
+          "version": "3.378.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.378.0.tgz",
+          "integrity": "sha512-l1DyaDLm3KeBMNMuANI3scWh8Xvu248x+vw6Z7ExWOhGXFmQ1MW7YvASg/SdxWkhlF9HmkkTif1LdMB22x6QDA==",
+          "requires": {
+            "@aws-sdk/types": "3.378.0",
+            "@smithy/types": "^2.0.2",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/middleware-recursion-detection": {
+          "version": "3.378.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.378.0.tgz",
+          "integrity": "sha512-mUMfHAz0oGNIWiTZHTVJb+I515Hqs2zx1j36Le4MMiiaMkPW1SRUF1FIwGuc1wh6E8jB5q+XfEMriDjRi4TZRA==",
+          "requires": {
+            "@aws-sdk/types": "3.378.0",
+            "@smithy/protocol-http": "^2.0.1",
+            "@smithy/types": "^2.0.2",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/middleware-sdk-sts": {
+          "version": "3.379.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.379.1.tgz",
+          "integrity": "sha512-SK3gSyT0XbLiY12+AjLFYL9YngxOXHnZF3Z33Cdd4a+AUYrVBV7JBEEGD1Nlwrcmko+3XgaKlmgUaR5s91MYvg==",
+          "requires": {
+            "@aws-sdk/middleware-signing": "3.379.1",
+            "@aws-sdk/types": "3.378.0",
+            "@smithy/types": "^2.0.2",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/middleware-signing": {
+          "version": "3.379.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.379.1.tgz",
+          "integrity": "sha512-kBk2ZUvR84EM4fICjr8K+Ykpf8SI1UzzPp2/UVYZ0X+4H/ZCjfSqohGRwHykMqeplne9qHSL7/rGJs1H3l3gPg==",
+          "requires": {
+            "@aws-sdk/types": "3.378.0",
+            "@smithy/property-provider": "^2.0.0",
+            "@smithy/protocol-http": "^2.0.1",
+            "@smithy/signature-v4": "^2.0.0",
+            "@smithy/types": "^2.0.2",
+            "@smithy/util-middleware": "^2.0.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/middleware-user-agent": {
+          "version": "3.386.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.386.0.tgz",
+          "integrity": "sha512-h6nVr5dvzrSLM+5BGbyqISh1p2NoTNv0+IZkMcGyig2jpdhbkMOPvvoOGMg16/cmelUQCguT26Jr7WYpLFDsTg==",
+          "requires": {
+            "@aws-sdk/types": "3.378.0",
+            "@aws-sdk/util-endpoints": "3.386.0",
+            "@smithy/protocol-http": "^2.0.1",
+            "@smithy/types": "^2.0.2",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/token-providers": {
+          "version": "3.386.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.386.0.tgz",
+          "integrity": "sha512-DStdqBtpO0FRC4mDCIPtrpLCFMnYJFo4cYlUyr9CKvKvh2IzPMU4rsKQjUhtmzdjLEvPTAcdfRx2Q9/sJkfe9Q==",
+          "requires": {
+            "@aws-sdk/types": "3.378.0",
+            "@smithy/property-provider": "^2.0.0",
+            "@smithy/shared-ini-file-loader": "^2.0.0",
+            "@smithy/types": "^2.0.2",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.378.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.378.0.tgz",
+          "integrity": "sha512-qP0CvR/ItgktmN8YXpGQglzzR/6s0nrsQ4zIfx3HMwpsBTwuouYahcCtF1Vr82P4NFcoDA412EJahJ2pIqEd+w==",
+          "requires": {
+            "@smithy/types": "^2.0.2",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/util-endpoints": {
+          "version": "3.386.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.386.0.tgz",
+          "integrity": "sha512-FDQRC9f78Kx12KsR43MukLRfqF3BNz5VfFdKP9ZYx3KK+bMjU1czjmjOS8bNMJWYM1Sn+nobBpPS3e2uupBtpg==",
+          "requires": {
+            "@aws-sdk/types": "3.378.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/util-user-agent-browser": {
+          "version": "3.378.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.378.0.tgz",
+          "integrity": "sha512-FSCpagzftK1W+m7Ar6lpX7/Gr9y5P56nhFYz8U4EYQ4PkufS6czWX9YW+/FA5OYV0vlQ/SvPqMnzoHIPUNhZrQ==",
+          "requires": {
+            "@aws-sdk/types": "3.378.0",
+            "@smithy/types": "^2.0.2",
+            "bowser": "^2.11.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/util-user-agent-node": {
+          "version": "3.378.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.378.0.tgz",
+          "integrity": "sha512-IdwVJV0E96MkJeFte4dlWqvB+oiqCiZ5lOlheY3W9NynTuuX0GGYNC8Y9yIsV8Oava1+ujpJq0ww6qXdYxmO4A==",
+          "requires": {
+            "@aws-sdk/types": "3.378.0",
+            "@smithy/node-config-provider": "^2.0.1",
+            "@smithy/types": "^2.0.2",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@smithy/protocol-http": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-2.0.2.tgz",
+          "integrity": "sha512-qWu8g1FUy+m36KpO1sREJSF7BaLmjw9AqOuwxLVVSdYz+nUQjc9tFAZ9LB6jJXKdsZFSjfkjHJBbhD78QdE7Rw==",
+          "requires": {
+            "@smithy/types": "^2.1.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@smithy/types": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.1.0.tgz",
+          "integrity": "sha512-KLsCsqxX0j2l99iP8s0f7LBlcsp7a7ceXGn0LPYPyVOsqmIKvSaPQajq0YevlL4T9Bm+DtcyXfBTbtBcLX1I7A==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        }
+      }
+    },
     "@aws-sdk/client-opensearch": {
       "version": "3.359.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-opensearch/-/client-opensearch-3.359.0.tgz",
@@ -8031,6 +9555,350 @@
         "tslib": "^2.5.0"
       }
     },
+    "@smithy/abort-controller": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.0.2.tgz",
+      "integrity": "sha512-ln5Cob0mksym62sLr7NiPOSqJ0jKao4qjfcNLDdgINM1lQI12hXrZBlKdPHbXJqpKhKiECDgonMoqCM8bigq4g==",
+      "requires": {
+        "@smithy/types": "^2.1.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "@smithy/types": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.1.0.tgz",
+          "integrity": "sha512-KLsCsqxX0j2l99iP8s0f7LBlcsp7a7ceXGn0LPYPyVOsqmIKvSaPQajq0YevlL4T9Bm+DtcyXfBTbtBcLX1I7A==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        }
+      }
+    },
+    "@smithy/config-resolver": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-2.0.2.tgz",
+      "integrity": "sha512-0kdsqBL6BdmSbdU6YaDkodVBMua5MuQQluC3nocJ7OJ6PnOuM7i2FEQHE46LBadLqT+CimlDSM+6j91uHNL1ng==",
+      "requires": {
+        "@smithy/types": "^2.1.0",
+        "@smithy/util-config-provider": "^2.0.0",
+        "@smithy/util-middleware": "^2.0.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "@smithy/types": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.1.0.tgz",
+          "integrity": "sha512-KLsCsqxX0j2l99iP8s0f7LBlcsp7a7ceXGn0LPYPyVOsqmIKvSaPQajq0YevlL4T9Bm+DtcyXfBTbtBcLX1I7A==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        }
+      }
+    },
+    "@smithy/credential-provider-imds": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-2.0.2.tgz",
+      "integrity": "sha512-mbWFYEZ00LBRDk3WvcXViwpdpkJQcfrM3seuKzFxZnF6wIBLMwrcWcsj+OUC/1L+86m8aQY9imXMAaQsAoGxow==",
+      "requires": {
+        "@smithy/node-config-provider": "^2.0.2",
+        "@smithy/property-provider": "^2.0.2",
+        "@smithy/types": "^2.1.0",
+        "@smithy/url-parser": "^2.0.2",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "@smithy/types": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.1.0.tgz",
+          "integrity": "sha512-KLsCsqxX0j2l99iP8s0f7LBlcsp7a7ceXGn0LPYPyVOsqmIKvSaPQajq0YevlL4T9Bm+DtcyXfBTbtBcLX1I7A==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        }
+      }
+    },
+    "@smithy/eventstream-codec": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-2.0.2.tgz",
+      "integrity": "sha512-PQZiKx7fMnNwx4zxcUCm82VjnqK6wV4MEHSmMy3taj5dKfXV782IjRGyaDT+8TsmNqVdZIkve5zLRAzh+7kOhA==",
+      "requires": {
+        "@aws-crypto/crc32": "3.0.0",
+        "@smithy/types": "^2.1.0",
+        "@smithy/util-hex-encoding": "^2.0.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "@smithy/types": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.1.0.tgz",
+          "integrity": "sha512-KLsCsqxX0j2l99iP8s0f7LBlcsp7a7ceXGn0LPYPyVOsqmIKvSaPQajq0YevlL4T9Bm+DtcyXfBTbtBcLX1I7A==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        }
+      }
+    },
+    "@smithy/fetch-http-handler": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-2.0.2.tgz",
+      "integrity": "sha512-Wo2m1RaiXNSLF4J3D62LpdSoj/YYb+6tn0H8is1tSrzr7eXAdiYVBc0wIa23N0wT4zmN0iG/yNY6gTCDQ6799A==",
+      "requires": {
+        "@smithy/protocol-http": "^2.0.2",
+        "@smithy/querystring-builder": "^2.0.2",
+        "@smithy/types": "^2.1.0",
+        "@smithy/util-base64": "^2.0.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "@smithy/protocol-http": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-2.0.2.tgz",
+          "integrity": "sha512-qWu8g1FUy+m36KpO1sREJSF7BaLmjw9AqOuwxLVVSdYz+nUQjc9tFAZ9LB6jJXKdsZFSjfkjHJBbhD78QdE7Rw==",
+          "requires": {
+            "@smithy/types": "^2.1.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@smithy/types": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.1.0.tgz",
+          "integrity": "sha512-KLsCsqxX0j2l99iP8s0f7LBlcsp7a7ceXGn0LPYPyVOsqmIKvSaPQajq0YevlL4T9Bm+DtcyXfBTbtBcLX1I7A==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        }
+      }
+    },
+    "@smithy/hash-node": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-2.0.2.tgz",
+      "integrity": "sha512-JKDzZ1YVR7JzOBaJoWy3ToJCE86OQE6D4kOBvvVsu93a3lcF9kv6KYTKBYEWAjwOn/CpK4NH7mKB01OQ8H+aiA==",
+      "requires": {
+        "@smithy/types": "^2.1.0",
+        "@smithy/util-buffer-from": "^2.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "@smithy/types": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.1.0.tgz",
+          "integrity": "sha512-KLsCsqxX0j2l99iP8s0f7LBlcsp7a7ceXGn0LPYPyVOsqmIKvSaPQajq0YevlL4T9Bm+DtcyXfBTbtBcLX1I7A==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        }
+      }
+    },
+    "@smithy/invalid-dependency": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-2.0.2.tgz",
+      "integrity": "sha512-inQZQ5gCO3WRWuXpsc1YJ4KBjsvj2qsoU32yTIKznBWTCQe/D5Dp+sSaysqBqxe0VTZ+8nFEHdUMWUX2BxQThw==",
+      "requires": {
+        "@smithy/types": "^2.1.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "@smithy/types": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.1.0.tgz",
+          "integrity": "sha512-KLsCsqxX0j2l99iP8s0f7LBlcsp7a7ceXGn0LPYPyVOsqmIKvSaPQajq0YevlL4T9Bm+DtcyXfBTbtBcLX1I7A==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        }
+      }
+    },
+    "@smithy/is-array-buffer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.0.0.tgz",
+      "integrity": "sha512-z3PjFjMyZNI98JFRJi/U0nGoLWMSJlDjAW4QUX2WNZLas5C0CmVV6LJ01JI0k90l7FvpmixjWxPFmENSClQ7ug==",
+      "requires": {
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/middleware-content-length": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-2.0.2.tgz",
+      "integrity": "sha512-FmHlNfuvYgDZE3fIx0G3rD/wLXfAmBYE4mVc/w6d7RllA7TygPzq2pfHL1iCMzWkWTdoAVnt3h4aavAZnhaxEQ==",
+      "requires": {
+        "@smithy/protocol-http": "^2.0.2",
+        "@smithy/types": "^2.1.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "@smithy/protocol-http": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-2.0.2.tgz",
+          "integrity": "sha512-qWu8g1FUy+m36KpO1sREJSF7BaLmjw9AqOuwxLVVSdYz+nUQjc9tFAZ9LB6jJXKdsZFSjfkjHJBbhD78QdE7Rw==",
+          "requires": {
+            "@smithy/types": "^2.1.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@smithy/types": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.1.0.tgz",
+          "integrity": "sha512-KLsCsqxX0j2l99iP8s0f7LBlcsp7a7ceXGn0LPYPyVOsqmIKvSaPQajq0YevlL4T9Bm+DtcyXfBTbtBcLX1I7A==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        }
+      }
+    },
+    "@smithy/middleware-endpoint": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-2.0.2.tgz",
+      "integrity": "sha512-ropE7/c+g22QeluZ+By/B/WvVep0UFreX+IeRMGIO7EbOUPgqtJRXpbJFdG6JKB1uC+CdaJLn4MnZnVBpcyjuA==",
+      "requires": {
+        "@smithy/middleware-serde": "^2.0.2",
+        "@smithy/types": "^2.1.0",
+        "@smithy/url-parser": "^2.0.2",
+        "@smithy/util-middleware": "^2.0.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "@smithy/types": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.1.0.tgz",
+          "integrity": "sha512-KLsCsqxX0j2l99iP8s0f7LBlcsp7a7ceXGn0LPYPyVOsqmIKvSaPQajq0YevlL4T9Bm+DtcyXfBTbtBcLX1I7A==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        }
+      }
+    },
+    "@smithy/middleware-retry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-2.0.2.tgz",
+      "integrity": "sha512-wtBUXqtZVriiXppYaFkUrybAPhFVX7vebnW/yVPliLMWMcguOMS58qhOYPZe3t9Wki2+mASfyu+kO3An8lAg2A==",
+      "requires": {
+        "@smithy/protocol-http": "^2.0.2",
+        "@smithy/service-error-classification": "^2.0.0",
+        "@smithy/types": "^2.1.0",
+        "@smithy/util-middleware": "^2.0.0",
+        "@smithy/util-retry": "^2.0.0",
+        "tslib": "^2.5.0",
+        "uuid": "^8.3.2"
+      },
+      "dependencies": {
+        "@smithy/protocol-http": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-2.0.2.tgz",
+          "integrity": "sha512-qWu8g1FUy+m36KpO1sREJSF7BaLmjw9AqOuwxLVVSdYz+nUQjc9tFAZ9LB6jJXKdsZFSjfkjHJBbhD78QdE7Rw==",
+          "requires": {
+            "@smithy/types": "^2.1.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@smithy/types": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.1.0.tgz",
+          "integrity": "sha512-KLsCsqxX0j2l99iP8s0f7LBlcsp7a7ceXGn0LPYPyVOsqmIKvSaPQajq0YevlL4T9Bm+DtcyXfBTbtBcLX1I7A==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        }
+      }
+    },
+    "@smithy/middleware-serde": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-2.0.2.tgz",
+      "integrity": "sha512-Kw9xLdlueIaivUWslKB67WZ/cCUg3QnzYVIA3t5KfgsseEEuU4UxXw8NSTvIt71gqQloY+Um8ugS+idgxrWWnw==",
+      "requires": {
+        "@smithy/types": "^2.1.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "@smithy/types": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.1.0.tgz",
+          "integrity": "sha512-KLsCsqxX0j2l99iP8s0f7LBlcsp7a7ceXGn0LPYPyVOsqmIKvSaPQajq0YevlL4T9Bm+DtcyXfBTbtBcLX1I7A==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        }
+      }
+    },
+    "@smithy/middleware-stack": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-2.0.0.tgz",
+      "integrity": "sha512-31XC1xNF65nlbc16yuh3wwTudmqs6qy4EseQUGF8A/p2m/5wdd/cnXJqpniy/XvXVwkHPz/GwV36HqzHtIKATQ==",
+      "requires": {
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/node-config-provider": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-2.0.2.tgz",
+      "integrity": "sha512-9wVJccASfuCctNWrzR0zrDkf0ox3HCHGEhFlWL2LBoghUYuK28pVRBbG69wvnkhlHnB8dDZHagxH+Nq9dm7eWw==",
+      "requires": {
+        "@smithy/property-provider": "^2.0.2",
+        "@smithy/shared-ini-file-loader": "^2.0.2",
+        "@smithy/types": "^2.1.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "@smithy/types": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.1.0.tgz",
+          "integrity": "sha512-KLsCsqxX0j2l99iP8s0f7LBlcsp7a7ceXGn0LPYPyVOsqmIKvSaPQajq0YevlL4T9Bm+DtcyXfBTbtBcLX1I7A==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        }
+      }
+    },
+    "@smithy/node-http-handler": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-2.0.2.tgz",
+      "integrity": "sha512-lpZjmtmyZqSAtMPsbrLhb7XoAQ2kAHeuLY/csW6I2k+QyFvOk7cZeQsqEngWmZ9SJaeYiDCBINxAIM61i5WGLw==",
+      "requires": {
+        "@smithy/abort-controller": "^2.0.2",
+        "@smithy/protocol-http": "^2.0.2",
+        "@smithy/querystring-builder": "^2.0.2",
+        "@smithy/types": "^2.1.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "@smithy/protocol-http": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-2.0.2.tgz",
+          "integrity": "sha512-qWu8g1FUy+m36KpO1sREJSF7BaLmjw9AqOuwxLVVSdYz+nUQjc9tFAZ9LB6jJXKdsZFSjfkjHJBbhD78QdE7Rw==",
+          "requires": {
+            "@smithy/types": "^2.1.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@smithy/types": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.1.0.tgz",
+          "integrity": "sha512-KLsCsqxX0j2l99iP8s0f7LBlcsp7a7ceXGn0LPYPyVOsqmIKvSaPQajq0YevlL4T9Bm+DtcyXfBTbtBcLX1I7A==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        }
+      }
+    },
+    "@smithy/property-provider": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.0.2.tgz",
+      "integrity": "sha512-DfaZ8cO+d/mgnMzIllcXcU4OYP+omiOl2LYdn/fTGpw/EAQSVzscYV2muV3sDDnuPYQ/r014hUqIxnF+pzh+SQ==",
+      "requires": {
+        "@smithy/types": "^2.1.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "@smithy/types": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.1.0.tgz",
+          "integrity": "sha512-KLsCsqxX0j2l99iP8s0f7LBlcsp7a7ceXGn0LPYPyVOsqmIKvSaPQajq0YevlL4T9Bm+DtcyXfBTbtBcLX1I7A==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        }
+      }
+    },
     "@smithy/protocol-http": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-1.0.1.tgz",
@@ -8040,11 +9908,293 @@
         "tslib": "^2.5.0"
       }
     },
+    "@smithy/querystring-builder": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-2.0.2.tgz",
+      "integrity": "sha512-H99LOMWEssfwqkOoTs4Y12UiZ7CTGQSX5Nrx5UkYgRbUEpC1GnnaprHiYrqclC58/xr4K76aNchdPyioxewMzA==",
+      "requires": {
+        "@smithy/types": "^2.1.0",
+        "@smithy/util-uri-escape": "^2.0.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "@smithy/types": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.1.0.tgz",
+          "integrity": "sha512-KLsCsqxX0j2l99iP8s0f7LBlcsp7a7ceXGn0LPYPyVOsqmIKvSaPQajq0YevlL4T9Bm+DtcyXfBTbtBcLX1I7A==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        }
+      }
+    },
+    "@smithy/querystring-parser": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-2.0.2.tgz",
+      "integrity": "sha512-L4VtKQ8O4/aWPQJbiFymbhAmxdfLnEaROh/Vs0OstJ7jtOZeBl2QJmuWY2V7hjt64W7V+tEn2sv6vVvnxkm/xQ==",
+      "requires": {
+        "@smithy/types": "^2.1.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "@smithy/types": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.1.0.tgz",
+          "integrity": "sha512-KLsCsqxX0j2l99iP8s0f7LBlcsp7a7ceXGn0LPYPyVOsqmIKvSaPQajq0YevlL4T9Bm+DtcyXfBTbtBcLX1I7A==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        }
+      }
+    },
+    "@smithy/service-error-classification": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-2.0.0.tgz",
+      "integrity": "sha512-2z5Nafy1O0cTf69wKyNjGW/sNVMiqDnb4jgwfMG8ye8KnFJ5qmJpDccwIbJNhXIfbsxTg9SEec2oe1cexhMJvw=="
+    },
+    "@smithy/shared-ini-file-loader": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.0.2.tgz",
+      "integrity": "sha512-2VkNOM/82u4vatVdK5nfusgGIlvR48Fkq6me17Oc+V1iyxfR/1x0pG6LzW0br1qlGtzBYFZKmDyviBRcPVFTVw==",
+      "requires": {
+        "@smithy/types": "^2.1.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "@smithy/types": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.1.0.tgz",
+          "integrity": "sha512-KLsCsqxX0j2l99iP8s0f7LBlcsp7a7ceXGn0LPYPyVOsqmIKvSaPQajq0YevlL4T9Bm+DtcyXfBTbtBcLX1I7A==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        }
+      }
+    },
+    "@smithy/signature-v4": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-2.0.2.tgz",
+      "integrity": "sha512-YMooDEw/UmGxcXY4qWnSXkbPFsRloluSvyXVT678YPDN/K2AS1GzKfRsvSU7fbccOB4WF8MHZf2UqcRGEltE3Q==",
+      "requires": {
+        "@smithy/eventstream-codec": "^2.0.2",
+        "@smithy/is-array-buffer": "^2.0.0",
+        "@smithy/types": "^2.1.0",
+        "@smithy/util-hex-encoding": "^2.0.0",
+        "@smithy/util-middleware": "^2.0.0",
+        "@smithy/util-uri-escape": "^2.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "@smithy/types": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.1.0.tgz",
+          "integrity": "sha512-KLsCsqxX0j2l99iP8s0f7LBlcsp7a7ceXGn0LPYPyVOsqmIKvSaPQajq0YevlL4T9Bm+DtcyXfBTbtBcLX1I7A==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        }
+      }
+    },
+    "@smithy/smithy-client": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-2.0.2.tgz",
+      "integrity": "sha512-mDfokI8WwLU5C0gcQ4ww/zJI/WLGSh2+vdIA42JRnjfYUjJNH/rKfX9YOnn2eBOxl3loATERVUqkHmKe+P8s2Q==",
+      "requires": {
+        "@smithy/middleware-stack": "^2.0.0",
+        "@smithy/types": "^2.1.0",
+        "@smithy/util-stream": "^2.0.2",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "@smithy/types": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.1.0.tgz",
+          "integrity": "sha512-KLsCsqxX0j2l99iP8s0f7LBlcsp7a7ceXGn0LPYPyVOsqmIKvSaPQajq0YevlL4T9Bm+DtcyXfBTbtBcLX1I7A==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        }
+      }
+    },
     "@smithy/types": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.0.0.tgz",
       "integrity": "sha512-kc1m5wPBHQCTixwuaOh9vnak/iJm21DrSf9UK6yDE5S3mQQ4u11pqAUiKWnlrZnYkeLfAI9UEHj9OaMT1v5Umg==",
       "requires": {
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/url-parser": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-2.0.2.tgz",
+      "integrity": "sha512-X1mHCzrSVDlhVy7d3S7Vq+dTfYzwh4n7xGHhyJumu77nJqIss0lazVug85Pwo0DKIoO314wAOvMnBxNYDa+7wA==",
+      "requires": {
+        "@smithy/querystring-parser": "^2.0.2",
+        "@smithy/types": "^2.1.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "@smithy/types": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.1.0.tgz",
+          "integrity": "sha512-KLsCsqxX0j2l99iP8s0f7LBlcsp7a7ceXGn0LPYPyVOsqmIKvSaPQajq0YevlL4T9Bm+DtcyXfBTbtBcLX1I7A==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        }
+      }
+    },
+    "@smithy/util-base64": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-2.0.0.tgz",
+      "integrity": "sha512-Zb1E4xx+m5Lud8bbeYi5FkcMJMnn+1WUnJF3qD7rAdXpaL7UjkFQLdmW5fHadoKbdHpwH9vSR8EyTJFHJs++tA==",
+      "requires": {
+        "@smithy/util-buffer-from": "^2.0.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/util-body-length-browser": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-2.0.0.tgz",
+      "integrity": "sha512-JdDuS4ircJt+FDnaQj88TzZY3+njZ6O+D3uakS32f2VNnDo3vyEuNdBOh/oFd8Df1zSZOuH1HEChk2AOYDezZg==",
+      "requires": {
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/util-body-length-node": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-2.0.0.tgz",
+      "integrity": "sha512-ZV7Z/WHTMxHJe/xL/56qZwSUcl63/5aaPAGjkfynJm4poILjdD4GmFI+V+YWabh2WJIjwTKZ5PNsuvPQKt93Mg==",
+      "requires": {
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/util-buffer-from": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.0.0.tgz",
+      "integrity": "sha512-/YNnLoHsR+4W4Vf2wL5lGv0ksg8Bmk3GEGxn2vEQt52AQaPSCuaO5PM5VM7lP1K9qHRKHwrPGktqVoAHKWHxzw==",
+      "requires": {
+        "@smithy/is-array-buffer": "^2.0.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/util-config-provider": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-2.0.0.tgz",
+      "integrity": "sha512-xCQ6UapcIWKxXHEU4Mcs2s7LcFQRiU3XEluM2WcCjjBtQkUN71Tb+ydGmJFPxMUrW/GWMgQEEGipLym4XG0jZg==",
+      "requires": {
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/util-defaults-mode-browser": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-2.0.2.tgz",
+      "integrity": "sha512-c2tMMjb624XLuzmlRoZpnFOkejVxcgw3WQKdmgdGZYZapcLzXyC0H9JhnXMjQCt30GqLTlsILRNVBYwFRbw/4Q==",
+      "requires": {
+        "@smithy/property-provider": "^2.0.2",
+        "@smithy/types": "^2.1.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "@smithy/types": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.1.0.tgz",
+          "integrity": "sha512-KLsCsqxX0j2l99iP8s0f7LBlcsp7a7ceXGn0LPYPyVOsqmIKvSaPQajq0YevlL4T9Bm+DtcyXfBTbtBcLX1I7A==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        }
+      }
+    },
+    "@smithy/util-defaults-mode-node": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-2.0.2.tgz",
+      "integrity": "sha512-gt7m5LLqUtEKldJLyc14DE4kb85vxwomvt9AfEMEvWM4VwfWS1kGJqiStZFb5KNqnQPXw8vvpgLTi8NrWAOXqg==",
+      "requires": {
+        "@smithy/config-resolver": "^2.0.2",
+        "@smithy/credential-provider-imds": "^2.0.2",
+        "@smithy/node-config-provider": "^2.0.2",
+        "@smithy/property-provider": "^2.0.2",
+        "@smithy/types": "^2.1.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "@smithy/types": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.1.0.tgz",
+          "integrity": "sha512-KLsCsqxX0j2l99iP8s0f7LBlcsp7a7ceXGn0LPYPyVOsqmIKvSaPQajq0YevlL4T9Bm+DtcyXfBTbtBcLX1I7A==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        }
+      }
+    },
+    "@smithy/util-hex-encoding": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-2.0.0.tgz",
+      "integrity": "sha512-c5xY+NUnFqG6d7HFh1IFfrm3mGl29lC+vF+geHv4ToiuJCBmIfzx6IeHLg+OgRdPFKDXIw6pvi+p3CsscaMcMA==",
+      "requires": {
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/util-middleware": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-2.0.0.tgz",
+      "integrity": "sha512-eCWX4ECuDHn1wuyyDdGdUWnT4OGyIzV0LN1xRttBFMPI9Ff/4heSHVxneyiMtOB//zpXWCha1/SWHJOZstG7kA==",
+      "requires": {
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/util-retry": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-2.0.0.tgz",
+      "integrity": "sha512-/dvJ8afrElasuiiIttRJeoS2sy8YXpksQwiM/TcepqdRVp7u4ejd9C4IQURHNjlfPUT7Y6lCDSa2zQJbdHhVTg==",
+      "requires": {
+        "@smithy/service-error-classification": "^2.0.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/util-stream": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-2.0.2.tgz",
+      "integrity": "sha512-Mg9IJcKIu4YKlbzvpp1KLvh4JZLdcPgpxk+LICuDwzZCfxe47R9enVK8dNEiuyiIGK2ExbfvzCVT8IBru62vZw==",
+      "requires": {
+        "@smithy/fetch-http-handler": "^2.0.2",
+        "@smithy/node-http-handler": "^2.0.2",
+        "@smithy/types": "^2.1.0",
+        "@smithy/util-base64": "^2.0.0",
+        "@smithy/util-buffer-from": "^2.0.0",
+        "@smithy/util-hex-encoding": "^2.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "@smithy/types": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.1.0.tgz",
+          "integrity": "sha512-KLsCsqxX0j2l99iP8s0f7LBlcsp7a7ceXGn0LPYPyVOsqmIKvSaPQajq0YevlL4T9Bm+DtcyXfBTbtBcLX1I7A==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        }
+      }
+    },
+    "@smithy/util-uri-escape": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-2.0.0.tgz",
+      "integrity": "sha512-ebkxsqinSdEooQduuk9CbKcI+wheijxEb3utGXkCoYQkJnwTnLbH1JXGimJtUkQwNQbsbuYwG2+aFVyZf5TLaw==",
+      "requires": {
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/util-utf8": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.0.0.tgz",
+      "integrity": "sha512-rctU1VkziY84n5OXe3bPNpKR001ZCME2JCaBBFgtiM2hfKbHFudc/BkMuPab8hRbLd0j3vbnBTTZ1igBf0wgiQ==",
+      "requires": {
+        "@smithy/util-buffer-from": "^2.0.0",
         "tslib": "^2.5.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "@aws-sdk/client-memorydb": "^3.347.1",
     "@aws-sdk/client-mq": "^3.347.1",
     "@aws-sdk/client-neptune": "^3.347.1",
+    "@aws-sdk/client-network-firewall": "^3.347.1",
     "@aws-sdk/client-opensearch": "^3.347.1",
     "@aws-sdk/client-organizations": "^3.347.1",
     "@aws-sdk/client-rds": "^3.347.1",


### PR DESCRIPTION
**Jira Link:**

[CSPM-1842](https://plerion.atlassian.net/browse/CSPM-1842)


**Summary/Motivation:**
- Added NetworkFirewall as a service to the Plerion asset counter to ensure network firewall instances are counted in total assets


**Testing Strategy:**
- Locally tested by running the counting script `aws.js` manually


**Dependencies:**
`@aws-sdk/client-network-firewall`


**Deployment Strategy:**

 

[CSPM-1842]: https://plerion.atlassian.net/browse/CSPM-1842?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ