### PR TITLE
CSPM-1822: asset counter

### DIFF
--- a/AWS/aws-dependencies.json
+++ b/AWS/aws-dependencies.json
@@ -1378,5 +1378,45 @@
         }
       }
     ]
+  },
+  {
+    "id": "InspectorV2",
+    "resources": [
+      {
+        "resourceType": "AWS::InspectorV2::Accounts",
+        "list": {
+          "action": {
+            "command": "BatchGetAccountStatus",
+            "outputProperty": "$.accounts",
+            "outputPropertySearchType": "JSON_PATH"
+          }
+        },
+        "listClientConfig": {
+          "clientName": "Inspector2Client",
+          "clientType": "AWS_V3",
+          "packageName": "@aws-sdk/client-inspector2"
+        }
+      }
+    ]
+  },
+  {
+    "id": "InspectorV2",
+    "resources": [
+      {
+        "resourceType": "AWS::InspectorV2::Accounts",
+        "list": {
+          "action": {
+            "command": "BatchGetAccountStatus",
+            "outputProperty": "$.accounts",
+            "outputPropertySearchType": "JSON_PATH"
+          }
+        },
+        "listClientConfig": {
+          "clientName": "Inspector2Client",
+          "clientType": "AWS_V3",
+          "packageName": "@aws-sdk/client-inspector2"
+        }
+      }
+    ]
   }
 ]

--- a/AWS/aws-dependencies.json
+++ b/AWS/aws-dependencies.json
@@ -222,6 +222,21 @@
           "clientType": "AWS_V3",
           "packageName": "@aws-sdk/client-inspector2"
         }
+      },
+      {
+        "resourceType": "AWS::InspectorV2::Account",
+        "list": {
+          "action": {
+            "command": "BatchGetAccountStatus",
+            "outputProperty": "$.accounts",
+            "outputPropertySearchType": "JSON_PATH"
+          }
+        },
+        "listClientConfig": {
+          "clientName": "Inspector2Client",
+          "clientType": "AWS_V3",
+          "packageName": "@aws-sdk/client-inspector2"
+        }
       }
     ]
   },
@@ -1380,41 +1395,21 @@
     ]
   },
   {
-    "id": "InspectorV2",
+    "id": "Organizations",
     "resources": [
       {
-        "resourceType": "AWS::InspectorV2::Accounts",
+        "resourceType": "AWS::Organizations::Account",
         "list": {
           "action": {
-            "command": "BatchGetAccountStatus",
-            "outputProperty": "$.accounts",
+            "command": "DescribeOrganization",
+            "outputProperty": "$.Organization",
             "outputPropertySearchType": "JSON_PATH"
           }
         },
         "listClientConfig": {
-          "clientName": "Inspector2Client",
+          "clientName": "OrganizationsClient",
           "clientType": "AWS_V3",
-          "packageName": "@aws-sdk/client-inspector2"
-        }
-      }
-    ]
-  },
-  {
-    "id": "InspectorV2",
-    "resources": [
-      {
-        "resourceType": "AWS::InspectorV2::Accounts",
-        "list": {
-          "action": {
-            "command": "BatchGetAccountStatus",
-            "outputProperty": "$.accounts",
-            "outputPropertySearchType": "JSON_PATH"
-          }
-        },
-        "listClientConfig": {
-          "clientName": "Inspector2Client",
-          "clientType": "AWS_V3",
-          "packageName": "@aws-sdk/client-inspector2"
+          "packageName": "@aws-sdk/client-organizations"
         }
       }
     ]

--- a/AWS/aws-dependencies.json
+++ b/AWS/aws-dependencies.json
@@ -1357,5 +1357,26 @@
         }
       }
     ]
+  },
+  {
+    "id": "Macie",
+    "resources": [
+      {
+        "resourceType": "AWS::Macie::Session",
+        "list": {
+          "action": {
+            "command": "GetMacieSession",
+            "outputProperty": "$.status",
+            "outputPropertySearchType": "JSON_PATH",
+            "resourceIdentifier": "MacieSession"
+          }
+        },
+        "listClientConfig": {
+          "clientName": "Macie2Client",
+          "clientType": "AWS_V3",
+          "packageName": "@aws-sdk/client-macie2"
+        }
+      }
+    ]
   }
 ]

--- a/AWS/aws-services.json
+++ b/AWS/aws-services.json
@@ -2279,5 +2279,32 @@
       "me-south-1",
       "us-east-2"
     ]
+  },
+  {
+    "service": "Macie",
+    "resources": [
+      { "resource": "Session", "resourceType": "AWS::Macie::Session" }
+    ],
+    "regions": [
+      "af-south-1",
+      "ap-northeast-1",
+      "ap-southeast-1",
+      "ca-central-1",
+      "eu-central-1",
+      "eu-west-3",
+      "us-east-2",
+      "us-west-2",
+      "ap-northeast-2",
+      "ap-northeast-3",
+      "ap-south-1",
+      "ap-southeast-2",
+      "eu-north-1",
+      "eu-west-1",
+      "eu-west-2",
+      "sa-east-1",
+      "us-west-1",
+      "us-east-1"
+    ],
+    "scope": "AWSAccount"
   }
 ]

--- a/AWS/aws-services.json
+++ b/AWS/aws-services.json
@@ -202,6 +202,10 @@
       {
         "resourceType": "AWS::InspectorV2::Findings",
         "resource": "ListFindings"
+      },
+      {
+        "resourceType": "AWS::InspectorV2::Account",
+        "resource": "Account"
       }
     ],
     "regions": [
@@ -318,6 +322,10 @@
       {
         "resource": "OrganizationalUnit",
         "resourceType": "AWS::Organizations::OrganizationalUnit"
+      },
+      {
+        "resource": "Account",
+        "resourceType": "AWS::Organizations::Account"
       }
     ],
     "regions": ["us-east-1"],


### PR DESCRIPTION
**Jira Link:**
[CSPM-1822](https://plerion.atlassian.net/browse/CSPM-1822)


**Summary/Motivation:**

- PLERION-AWS-175
  - As a Plerion Platform user I want to receive a ‘PASSED' finding if Amazon Macie is enabled
  - As a Plerion Platform user I want to receive a ‘FAILED' finding if Amazon Macie is disabled
- PLERION-AWS-811
  - As a Plerion Platform user I want to receive a ‘PASSED’ finding if the AWS account associated to my integration is part of an AWS Organization
  - As a Plerion Platform user I want to receive a ‘FAILED’ finding if the AWS account associated to my integration is not part of an AWS Organization
  - As a Plerion Platform user I want to receive an ‘UNKNOWN' finding if the AWS account associated to my integration is the Organization’s managed account
- PLERION-AWS-812
  - As a Plerion Platform user I want to receive a ‘PASSED' finding if Amazon Inspector is enabled
  - As a Plerion Platform user I want to receive a ‘FAILED' finding if Amazon Inspector is disabled


[CSPM-1822]: https://plerion.atlassian.net/browse/CSPM-1822?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ