### PR TITLE
feat: CSPM-1843 Ensure AWS Site-To-Site VPN has two tunnels up

### DIFF
--- a/AWS/aws-dependencies.json
+++ b/AWS/aws-dependencies.json
@@ -189,6 +189,21 @@
           "clientType": "AWS_V3",
           "packageName": "@aws-sdk/client-ec2"
         }
+      },
+      {
+        "resourceType": "AWS::EC2::VPN",
+        "list": {
+          "action": {
+            "command": "DescribeVpnConnections",
+            "outputProperty": "VpnConnections",
+            "resourceIdentifier": "VpnConnectionId"
+          }
+        },
+        "listClientConfig": {
+          "clientName": "EC2Client",
+          "clientType": "AWS_V3",
+          "packageName": "@aws-sdk/client-ec2"
+        }
       }
     ]
   },

--- a/AWS/aws-services.json
+++ b/AWS/aws-services.json
@@ -92,6 +92,7 @@
       },
       { "resource": "Instance", "resourceType": "AWS::EC2::Instance" },
       { "resource": "VPC", "resourceType": "AWS::EC2::VPC" },
+      { "resource": "VPN", "resourceType": "AWS::EC2::VPN" },
       { "resource": "FlowLog", "resourceType": "AWS::EC2::FlowLog" },
       { "resource": "NetworkAcl", "resourceType": "AWS::EC2::NetworkAcl" },
       {


### PR DESCRIPTION
Jira Link:

[CSPM-1843](https://plerion.atlassian.net/browse/CSPM-1843)

Summary/Motivation:

Added VPN as service to the Plerion asset counter to ensure their instances are counted in total assets

Testing Strategy:

Locally tested by running the counting script aws.js manually


[CSPM-1843]: https://plerion.atlassian.net/browse/CSPM-1843?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ