### PR TITLE
feat: CSPM-2023 DocumentDB DSPM Detections (Encryption at rest, Encryption in transit, Backups, Access logging)

### DIFF
--- a/AWS/aws-services.json
+++ b/AWS/aws-services.json
@@ -1903,7 +1903,8 @@
     "service": "DocDB",
     "resources": [
       { "resource": "DBInstance", "resourceType": "AWS::DocDB::DBInstance" },
-      { "resource": "DBCluster", "resourceType": "AWS::DocDB::DBCluster" }
+      { "resource": "DBCluster", "resourceType": "AWS::DocDB::DBCluster" },
+      { "resource": "DBClusterParameterGroup", "resourceType": "AWS::DocDB::DBClusterParameterGroup" }
     ],
     "regions": [
       "ap-northeast-1",


### PR DESCRIPTION
### Jira Link
[CSPM-2023](https://plerion.atlassian.net/browse/CSPM-2023)

### Summary
We have added the asset count for `AWS::DocDB::DBClusterParameterGroup`

<img width="1098" alt="Screenshot 2023-09-18 at 16 09 55" src="https://github.com/plerionhq/plerion-asset-counter/assets/139095828/7d9058ea-eee4-4109-ace9-b4540e9c0f16">


[CSPM-2023]: https://plerion.atlassian.net/browse/CSPM-2023?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ