### PR TITLE
fix: CSPM-2811 Returning integer, not object

### DIFF
--- a/AWS/collectors/custom/ECS/Service.js
+++ b/AWS/collectors/custom/ECS/Service.js
@@ -66,7 +66,7 @@ export const query = async (AWS_MAPPING, serviceName, resourceType, region) => {
           AWS_MAPPING,
           serviceName,
           ECS_TASK_DEFINITION,
-          { cspmUnits: taskDefs.length }
+          taskDefs.length,
         );
         total += taskDefs.length;
 


### PR DESCRIPTION
- For two collectors we were returning an object instead of a number which caused the tool to try and handle objects as numbers