### PR TITLE
feat: CSPM-2842 Allow Plerion Asset Counter to be run from AWS Org Management Account

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,4 +42,4 @@ dist/**/*
 yarn.lock
 .serverless
 
-AWS-output.json
+*-output.json

--- a/AWS/aws.js
+++ b/AWS/aws.js
@@ -8,11 +8,17 @@ import { queryDependencies, checkModuleAndQuery } from "./service/index.js";
 
 const AWS_MAPPING = { total: 0 };
 
-export const queryAWS = async (parsedService, parsedResourceType, verbose) => {
+export const queryAWS = async (
+  parsedService,
+  parsedResourceType,
+  verbose,
+  accountId,
+) => {
+  const accountIdText = accountId ? ` for AWS Account ${accountId}` : "";
   await Promise.all(
     services.map(async (service) => {
       const { regions, service: serviceName, resources } = service;
-      console.log(`Calculating ${serviceName}...`);
+      console.log(`Calculating ${serviceName}${accountIdText}...`);
       if (parsedService && parsedService !== serviceName) {
         return;
       }
@@ -59,7 +65,7 @@ export const queryAWS = async (parsedService, parsedResourceType, verbose) => {
           }
         }
       }
-      console.log(`Finished calculating ${serviceName}`);
+      console.log(`Finished calculating ${serviceName}${accountIdText}`);
     }),
   );
   return AWS_MAPPING;

--- a/AWS/aws.js
+++ b/AWS/aws.js
@@ -8,10 +8,11 @@ import { queryDependencies, checkModuleAndQuery } from "./service/index.js";
 
 const AWS_MAPPING = { total: 0 };
 
-export const queryAWS = async (parsedService, parsedResourceType) => {
+export const queryAWS = async (parsedService, parsedResourceType, verbose) => {
   await Promise.all(
     services.map(async (service) => {
       const { regions, service: serviceName, resources } = service;
+      console.log(`Calculating ${serviceName}...`);
       if (parsedService && parsedService !== serviceName) {
         return;
       }
@@ -30,7 +31,9 @@ export const queryAWS = async (parsedService, parsedResourceType) => {
             process.cwd(),
             `${providerName}/collectors/custom/${serviceName}/${resourceName}.js`,
           );
-          console.log(`Checking ${resourceType} on region ${region}`);
+          if (verbose) {
+            console.log(`Checking ${resourceType} on region ${region}`);
+          }
 
           const success = await checkModuleAndQuery(
             filePath,
@@ -49,11 +52,14 @@ export const queryAWS = async (parsedService, parsedResourceType) => {
                 region,
               );
             } catch (err) {
-              console.log(`Error checking ${resourceType} on ${region}`);
+              if (verbose) {
+                console.log(`Error checking ${resourceType} on ${region}`);
+              }
             }
           }
         }
       }
+      console.log(`Finished calculating ${serviceName}`);
     }),
   );
   return AWS_MAPPING;

--- a/AWS/collectors/custom/AutoScaling/AutoScalingGroup.js
+++ b/AWS/collectors/custom/AutoScaling/AutoScalingGroup.js
@@ -67,9 +67,12 @@ export const query = async (AWS_MAPPING, serviceName, resourceType, region) => {
       const amiScanned = [
         ...new Set(asgInstances.map((instance) => ec2AmiMap[instance])),
       ];
-      updateResourceTypeCounter(AWS_MAPPING, serviceName, resourceType, {
-        cwppUnits: amiScanned.length,
-      });
+      updateResourceTypeCounter(
+        AWS_MAPPING,
+        serviceName,
+        resourceType,
+        amiScanned.length,
+      );
       total += amiScanned.length;
     });
   } catch (error) {

--- a/AWS/collectors/custom/AutoScaling/AutoScalingGroup.js
+++ b/AWS/collectors/custom/AutoScaling/AutoScalingGroup.js
@@ -73,7 +73,9 @@ export const query = async (AWS_MAPPING, serviceName, resourceType, region) => {
       total += amiScanned.length;
     });
   } catch (error) {
-    console.log(`Error finding ${resourceType}`);
+    console.log(
+      `Error finding ${resourceType} on region ${region}. Region could be disabled. Continuing...`,
+    );
   }
   AWS_MAPPING.total += total;
 };

--- a/AWS/collectors/custom/EC2/Instance.js
+++ b/AWS/collectors/custom/EC2/Instance.js
@@ -37,7 +37,9 @@ export const query = async (AWS_MAPPING, serviceName, resourceType, region) => {
       ec2InstancesCount,
     );
   } catch (err) {
-    console.log(`Error finding ${resourceType}`);
+    console.log(
+      `Error finding ${resourceType} on region ${region}. Region could be disabled. Continuing...`,
+    );
   }
   AWS_MAPPING.total += total;
 };

--- a/AWS/collectors/custom/ECS/Service.js
+++ b/AWS/collectors/custom/ECS/Service.js
@@ -82,7 +82,7 @@ export const query = async (AWS_MAPPING, serviceName, resourceType, region) => {
               AWS_MAPPING,
               serviceName,
               ECS_TASK_DEFINITION,
-              { cwppUnits: containerCount },
+              containerCount,
             );
             total += containerCount;
           }),

--- a/AWS/utils/index.js
+++ b/AWS/utils/index.js
@@ -32,8 +32,17 @@ export const updateResourceTypeCounter = (
   resourceType,
   value,
 ) => {
+  if (typeof value !== "number") {
+    console.log(
+      `${serviceName} ${resourceType} DID NOT RECEIVE NUMBER FOR VALUE`,
+    );
+    process.exit(1);
+  }
   const service = AWS_MAPPING[serviceName] || {};
-  const updatedCount = updateCount(service[resourceType] || (isInteger(value) ? 0 : {}), value);
+  const updatedCount = updateCount(
+    service[resourceType] || (isInteger(value) ? 0 : {}),
+    value,
+  );
 
   AWS_MAPPING[serviceName] = {
     ...(AWS_MAPPING[serviceName] || {}),
@@ -53,7 +62,8 @@ const updateCount = (currentValue, increment) => {
   }
 };
 
-const isInteger = (input) => (typeof input === 'number' && Number.isInteger(input))
+const isInteger = (input) =>
+  typeof input === "number" && Number.isInteger(input);
 
 export const batchArray = (array, batchSize) => {
   const batchedArray = [];
@@ -61,4 +71,4 @@ export const batchArray = (array, batchSize) => {
     batchedArray.push(array.slice(i, i + batchSize));
   }
   return batchedArray;
-}
+};

--- a/README.md
+++ b/README.md
@@ -20,3 +20,7 @@ error if there are no resources in that region.
 ## Docker instructions
 1. `docker build -t asset-counter .`
 2. `docker run --rm -e AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN=$AWS_SESSION_TOKEN asset-counter -p AWS`
+
+## How to run for an AWS account using an AWS Organization Management Account
+1. Give `run_on_aws_management_account.sh` permission to run. `chmod +x run_on_aws_management_account.sh`
+2. Assume Role into your AWS Organization Management Account using admin access

--- a/README.md
+++ b/README.md
@@ -24,3 +24,8 @@ error if there are no resources in that region.
 ## How to run for an AWS account using an AWS Organization Management Account
 1. Give `run_on_aws_management_account.sh` permission to run. `chmod +x run_on_aws_management_account.sh`
 2. Assume Role into your AWS Organization Management Account using admin access
+3. You can verify this by running `aws sts get-caller-identity` and checking if the outputed `Account` field is the same as the AWS Organization Management Account's id
+4. Run the script `./run_on_aws_management_account.sh`
+5. For each member account it will assume either the `OrganizationAccountAccessRole` by default, or an otherwise specified role. [`OrganizationAccountAccessRole` is a default role which managed accounts automatically have](https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_accounts_access.html).
+6. If you have many member accounts this script may take some time to run. Each time a member account's run has completed it'll create a new file called `<awsAccountId>-AWS-Output.json`
+7. Once completely done it will create a file `AWS-Organization-output.json` which will contain estimated Plerion Unit consumption data for your entire Organization

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ error if there are no resources in that region.
 1. `docker build -t asset-counter .`
 2. `docker run --rm -e AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN=$AWS_SESSION_TOKEN asset-counter -p AWS`
 
-## How to run for an AWS account using an AWS Organization Management Account
+## Using with an AWS Organization Management Account
 1. Give `run_on_aws_management_account.sh` permission to run. `chmod +x run_on_aws_management_account.sh`
 2. Assume Role into your AWS Organization Management Account using admin access
 3. You can verify this by running `aws sts get-caller-identity` and checking if the outputed `Account` field is the same as the AWS Organization Management Account's id

--- a/README.md
+++ b/README.md
@@ -22,10 +22,12 @@ error if there are no resources in that region.
 2. `docker run --rm -e AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN=$AWS_SESSION_TOKEN asset-counter -p AWS`
 
 ## Using with an AWS Organization Management Account
-1. Give `run_on_aws_management_account.sh` permission to run. `chmod +x run_on_aws_management_account.sh`
-2. Assume Role into your AWS Organization Management Account using admin access
-3. You can verify this by running `aws sts get-caller-identity` and checking if the outputed `Account` field is the same as the AWS Organization Management Account's id
-4. Run the script `./run_on_aws_management_account.sh`
-5. For each member account it will assume either the `OrganizationAccountAccessRole` by default, or an otherwise specified role. [`OrganizationAccountAccessRole` is a default role which managed accounts automatically have](https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_accounts_access.html).
-6. If you have many member accounts this script may take some time to run. Each time a member account's run has completed it'll create a new file called `<awsAccountId>-AWS-Output.json`
-7. Once completely done it will create a file `AWS-Organization-output.json` which will contain estimated Plerion Unit consumption data for your entire Organization
+1. Run `npm i` to install packages
+2. [Ensure you have `jq` installed (`brew install jq`)](https://jqlang.github.io/jq/)
+3. Give `run_on_aws_management_account.sh` permission to run. `chmod +x run_on_aws_management_account.sh`
+4. Assume Role into your AWS Organization Management Account using admin access
+5. You can verify this by running `aws sts get-caller-identity` and checking if the outputed `Account` field is the same as the AWS Organization Management Account's id
+6. Run the script `./run_on_aws_management_account.sh`
+7. For each member account it will assume either the `OrganizationAccountAccessRole` by default, or an otherwise specified role. [`OrganizationAccountAccessRole` is a default role which managed accounts automatically have](https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_accounts_access.html).
+8. If you have many member accounts this script may take some time to run. Each time a member account's run has completed it'll create a new file called `<awsAccountId>-AWS-Output.json`
+9. Once completely done it will create a file `AWS-Organization-output.json` which will contain estimated Plerion Unit consumption data for your entire Organization

--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ program
   .option("-p, --provider <provider>")
   .option("-s, --service <service>")
   .option("-r, --resource <resource>")
+  .option("--accountId <a provider's account id to prefix the output file>")
   .option("-v, --verbose", "Verbose resource type logging");
 
 program.parse();
@@ -30,20 +31,29 @@ const calculateUnits = (result, provider) => {
       if (serviceUnits && serviceUnits[resourceType] !== undefined) {
         cwppUnits +=
           serviceUnits[resourceType] *
-          (serviceResourceTypesCounts[resourceType]['cwppUnits'] || serviceResourceTypesCounts[resourceType]);
+          (serviceResourceTypesCounts[resourceType]["cwppUnits"] ||
+            serviceResourceTypesCounts[resourceType]);
       }
-      cspmUnits += (serviceResourceTypesCounts[resourceType]['cspmUnits'] || serviceResourceTypesCounts[resourceType]);
+      cspmUnits +=
+        serviceResourceTypesCounts[resourceType]["cspmUnits"] ||
+        serviceResourceTypesCounts[resourceType];
     });
   });
   return { CSPM: cspmUnits, CWPP: cwppUnits };
 };
 
 (async () => {
-  const { provider, service, resource: resourceType, verbose } = options;
+  const {
+    provider,
+    service,
+    resource: resourceType,
+    verbose,
+    accountId,
+  } = options;
   let result;
   switch (provider) {
     case AWS:
-      result = await queryAWS(service, resourceType);
+      result = await queryAWS(service, resourceType, verbose);
       break;
   }
   const { CSPM: CSPM_UNITS, CWPP: CWPP_UNITS } = calculateUnits(
@@ -83,8 +93,9 @@ const calculateUnits = (result, provider) => {
   if (verbose) {
     await writeFile(`${provider}-output.json`, JSON.stringify(result, null, 2));
   } else {
+    const accountIdPrefix = accountId ? `${accountId}-` : "";
     await writeFile(
-      `${provider}-output.json`,
+      `${accountIdPrefix}${provider}-output.json`,
       JSON.stringify(
         {
           TOTAL: result.total,

--- a/index.js
+++ b/index.js
@@ -53,7 +53,7 @@ const calculateUnits = (result, provider) => {
   let result;
   switch (provider) {
     case AWS:
-      result = await queryAWS(service, resourceType, verbose);
+      result = await queryAWS(service, resourceType, verbose, accountId);
       break;
   }
   const { CSPM: CSPM_UNITS, CWPP: CWPP_UNITS } = calculateUnits(

--- a/run_on_aws_management_account.sh
+++ b/run_on_aws_management_account.sh
@@ -1,0 +1,111 @@
+#!/bin/bash
+
+# Step 1: Ask for role name with default value
+#read -p "Enter the role name (default: OrganizationAccountAccessRole): " role_name
+#role_name=${role_name:-OrganizationAccountAccessRole}
+#
+## Store original environment variables
+#original_aws_access_key_id=$AWS_ACCESS_KEY_ID
+#original_aws_secret_access_key=$AWS_SECRET_ACCESS_KEY
+#original_aws_session_token=$AWS_SESSION_TOKEN
+#
+## Step 2: List accounts in the organization using management account credentials
+#accounts=$(aws organizations list-accounts --output text --query 'Accounts[*].Id')
+#
+## Step 3: For each member account, assume the specified role and run the original script
+#for account_id in $accounts; do
+#    echo "Assuming role $role_name in account $account_id..."
+#    assumed_role=$(aws sts assume-role --role-arn arn:aws:iam::$account_id:role/$role_name --role-session-name "AssumeRoleSession")
+#    export AWS_ACCESS_KEY_ID=$(echo $assumed_role | jq -r '.Credentials.AccessKeyId')
+#    export AWS_SECRET_ACCESS_KEY=$(echo $assumed_role | jq -r '.Credentials.SecretAccessKey')
+#    export AWS_SESSION_TOKEN=$(echo $assumed_role | jq -r '.Credentials.SessionToken')
+#
+#    echo "Running script in account $account_id..."
+#
+#    node index.js -p AWS --accountId $account_id
+#
+#    # Restore original environment variables
+#    export AWS_ACCESS_KEY_ID=$original_aws_access_key_id
+#    export AWS_SECRET_ACCESS_KEY=$original_aws_secret_access_key
+#    export AWS_SESSION_TOKEN=$original_aws_session_token
+#done
+#
+## Unset temporary variables
+#unset original_aws_access_key_id
+#unset original_aws_secret_access_key
+#unset original_aws_session_token
+
+# Initialize variables to hold the sum
+total_cspm=0
+total_cwpp=0
+total_total=0
+
+# Iterate through files with the prefix "<someNumber>-AWS-output.json"
+for file in *-AWS-output.json; do
+    echo "Processing file: $file"
+    # Extract values from the file using jq and sum them
+    total=$(jq '.TOTAL' "$file")
+    cspm_units=$(jq '.CSPM_UNITS' "$file")
+    cwpp_cspm_units=$(jq '.CWPP_UNITS' "$file")
+    total_units=$(jq '.TOTAL_UNITS' "$file")
+    days_per_month=30
+    cspm_units_per_monthly_cspm=$(jq '.CSPM_UNITS_PER_MONTH' "$file")
+    cwpp_units_per_month=$(jq '.CWPP_UNITS_PER_MONTH' "$file")
+    total_units_per_month=$(jq '.TOTAL_UNITS_PER_MONTH' "$file")
+    info_cspm_ciem_asset_unit_base_consumption=1
+    info_cwpp_asset_unit_base_consumption=10
+    info_days_per_month=30
+    daily_cspm=$(jq '.DAILY.CSPM_CIEM_ASSET_UNITS' "$file")
+    daily_cwpp=$(jq '.DAILY.CWPP_ASSET_UNITS' "$file")
+    daily_total=$(jq '.DAILY.TOTAL_ASSET_UNITS' "$file")
+    monthly_cspm=$(jq '.MONTHLY.CSPM_CIEM_ASSET_UNITS' "$file")
+    monthly_cwpp=$(jq '.MONTHLY.CWPP_ASSET_UNITS' "$file")
+    monthly_total=$(jq '.MONTHLY.TOTAL_ASSET_UNITS' "$file")
+
+    # Add extracted values to the totals
+    total_all=$((total_all + total))
+    total_cspm_units=$((total_cspm_units + cspm_units))
+    total_cwpp_cspm_units=$((total_cwpp_cspm_units + cwpp_cspm_units))
+    total_all_units=$((total_all_units + total_units))
+    total_cspm_units_per_monthly_cspm=$((total_cspm_units_per_monthly_cspm + cspm_units_per_monthly_cspm))
+    total_cwpp_units_per_month=$((total_cwpp_units_per_month + cwpp_units_per_month))
+    total_all_units_per_month=$((total_all_units_per_month + total_units_per_month))
+    total_daily_cspm=$((total_daily_cspm + daily_cspm))
+    total_daily_cwpp=$((total_daily_cwpp + daily_cwpp))
+    total_daily_total=$((total_daily_total + daily_total))
+    total_monthly_cspm=$((total_monthly_cspm + monthly_cspm))
+    total_monthly_cwpp=$((total_monthly_cwpp + monthly_cwpp))
+    total_monthly_total=$((total_monthly_total + monthly_total))
+done
+
+# Create JSON structure for the sums
+json_output='{
+ "TOTAL": '$total_all',
+ "CSPM_UNITS": '$total_cspm_units',
+ "CWPP_UNITS": '$total_cwpp_cspm_units',
+ "TOTAL_UNITS": '$total_all_units',
+ "DAYS_PER_MONTH": '$days_per_month',
+ "CSPM_UNITS_PER_MONTH": '$total_cspm_units_per_monthly_cspm',
+ "CWPP_UNITS_PER_MONTH": '$total_cwpp_units_per_month',
+ "TOTAL_UNITS_PER_MONTH": '$total_all_units_per_month',
+ "INFO": {
+   "CSPM_CIEM_ASSET_UNIT_BASE_CONSUMPTION": '$info_cspm_ciem_asset_unit_base_consumption',
+   "CWPP_ASSET_UNIT_BASE_CONSUMPTION": '$info_cwpp_asset_unit_base_consumption',
+   "TOTAL_DAYS_PER_MONTH": '$info_days_per_month'
+ },
+ "DAILY": {
+   "CSPM_CIEM_ASSET_UNITS": '$total_daily_cspm',
+   "CWPP_ASSET_UNITS": '$total_daily_cwpp',
+   "TOTAL_ASSET_UNITS": '$total_daily_total'
+ },
+ "MONTHLY": {
+   "CSPM_CIEM_ASSET_UNITS": '$total_monthly_cspm',
+   "CWPP_ASSET_UNITS": '$total_monthly_cwpp',
+   "TOTAL_ASSET_UNITS": '$total_monthly_total'
+ }
+}'
+
+# Write JSON output to a file
+echo "$json_output" > AWS-Organization-output.json
+
+echo "Summed values written to AWS-Organization-output.json"

--- a/run_on_aws_management_account.sh
+++ b/run_on_aws_management_account.sh
@@ -1,39 +1,39 @@
 #!/bin/bash
 
 # Step 1: Ask for role name with default value
-#read -p "Enter the role name (default: OrganizationAccountAccessRole): " role_name
-#role_name=${role_name:-OrganizationAccountAccessRole}
-#
-## Store original environment variables
-#original_aws_access_key_id=$AWS_ACCESS_KEY_ID
-#original_aws_secret_access_key=$AWS_SECRET_ACCESS_KEY
-#original_aws_session_token=$AWS_SESSION_TOKEN
-#
-## Step 2: List accounts in the organization using management account credentials
-#accounts=$(aws organizations list-accounts --output text --query 'Accounts[*].Id')
-#
-## Step 3: For each member account, assume the specified role and run the original script
-#for account_id in $accounts; do
-#    echo "Assuming role $role_name in account $account_id..."
-#    assumed_role=$(aws sts assume-role --role-arn arn:aws:iam::$account_id:role/$role_name --role-session-name "AssumeRoleSession")
-#    export AWS_ACCESS_KEY_ID=$(echo $assumed_role | jq -r '.Credentials.AccessKeyId')
-#    export AWS_SECRET_ACCESS_KEY=$(echo $assumed_role | jq -r '.Credentials.SecretAccessKey')
-#    export AWS_SESSION_TOKEN=$(echo $assumed_role | jq -r '.Credentials.SessionToken')
-#
-#    echo "Running script in account $account_id..."
-#
-#    node index.js -p AWS --accountId $account_id
-#
-#    # Restore original environment variables
-#    export AWS_ACCESS_KEY_ID=$original_aws_access_key_id
-#    export AWS_SECRET_ACCESS_KEY=$original_aws_secret_access_key
-#    export AWS_SESSION_TOKEN=$original_aws_session_token
-#done
-#
-## Unset temporary variables
-#unset original_aws_access_key_id
-#unset original_aws_secret_access_key
-#unset original_aws_session_token
+read -p "Enter the role name (default: OrganizationAccountAccessRole): " role_name
+role_name=${role_name:-OrganizationAccountAccessRole}
+
+# Store original environment variables
+original_aws_access_key_id=$AWS_ACCESS_KEY_ID
+original_aws_secret_access_key=$AWS_SECRET_ACCESS_KEY
+original_aws_session_token=$AWS_SESSION_TOKEN
+
+# Step 2: List accounts in the organization using management account credentials
+accounts=$(aws organizations list-accounts --output text --query 'Accounts[*].Id')
+
+# Step 3: For each member account, assume the specified role and run the original script
+for account_id in $accounts; do
+    echo "Assuming role $role_name in account $account_id..."
+    assumed_role=$(aws sts assume-role --role-arn arn:aws:iam::$account_id:role/$role_name --role-session-name "AssumeRoleSession")
+    export AWS_ACCESS_KEY_ID=$(echo $assumed_role | jq -r '.Credentials.AccessKeyId')
+    export AWS_SECRET_ACCESS_KEY=$(echo $assumed_role | jq -r '.Credentials.SecretAccessKey')
+    export AWS_SESSION_TOKEN=$(echo $assumed_role | jq -r '.Credentials.SessionToken')
+
+    echo "Running script in account $account_id..."
+
+    node index.js -p AWS --accountId $account_id
+
+    # Restore original environment variables
+    export AWS_ACCESS_KEY_ID=$original_aws_access_key_id
+    export AWS_SECRET_ACCESS_KEY=$original_aws_secret_access_key
+    export AWS_SESSION_TOKEN=$original_aws_session_token
+done
+
+# Unset temporary variables
+unset original_aws_access_key_id
+unset original_aws_secret_access_key
+unset original_aws_session_token
 
 # Initialize variables to hold the sum
 total_cspm=0


### PR DESCRIPTION
- Allows the Plerion Asset Counter to be run from AWS Org Management Account
- Puts a lot of logging noise behind the `--verbose` flag
