### PR TITLE
feat CWPP-1450: add CWPP asset count support for K8s resources

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -8,6 +8,14 @@ export const UNIT_MAPPING = {
     ECS: { "AWS::ECS::TaskDefinition": 10 },
     AutoScaling: { "AWS::AutoScaling::AutoScalingGroup": 10 },
   },
+  K8S: {
+    pods: 10,
+    deployments: 10,
+    statefulsets: 10,
+    daemonsets: 10,
+    jobs: 10,
+    cronjobs: 10,
+  },
 };
 
 export const DAYS_PER_MONTH = 30;

--- a/k8s/index.js
+++ b/k8s/index.js
@@ -77,9 +77,9 @@ const getResourcesToQuery = (requestedResources) => {
   return resourcesToQuery;
 };
 
-const getOwnerLessPods = (pods) => {
-  return pods.filter((podsDescription) => {
-    const ownerReferences = podsDescription.metadata.ownerReferences;
+const getOwnerLessResources = (resources) => {
+  return resources.filter((resourceDescription) => {
+    const ownerReferences = resourceDescription.metadata.ownerReferences;
     if (!ownerReferences) return true;
 
     return ownerReferences.some(
@@ -100,8 +100,8 @@ export const queryKubernetes = async (requestedResources, verbose) => {
         true,
       );
       let resources = [];
-      if (resourceName === "pods") {
-        resources = getOwnerLessPods(resourceResponse.items);
+      if (k8sResource.allowsOwnership) {
+        resources = getOwnerLessResources(resourceResponse.items);
       } else {
         resources = resourceResponse.items;
       }

--- a/k8s/k8-resources.json
+++ b/k8s/k8-resources.json
@@ -12,6 +12,7 @@
       "po"
     ],
     "apiVersion": "v1",
+    "isWorkload": true,
     "nameSpaced": true,
     "kind": "Pod"
   },
@@ -30,6 +31,7 @@
       "deploy"
     ],
     "apiVersion": "apps/v1",
+    "isWorkload": true,
     "nameSpaced": true,
     "kind": "Deployment"
   },
@@ -39,6 +41,7 @@
       "sts"
     ],
     "apiVersion": "apps/v1",
+    "isWorkload": true,
     "nameSpaced": true,
     "kind": "StatefulSet"
   },
@@ -49,12 +52,14 @@
     ],
     "apiVersion": "apps/v1",
     "nameSpaced": true,
+    "isWorkload": true,
     "kind": "DaemonSet"
   },
   "Kubernetes::Workload::Job": {
     "name": "jobs",
     "shortNames": null,
     "apiVersion": "batch/v1",
+    "isWorkload": true,
     "nameSpaced": true,
     "kind": "Job"
   },
@@ -65,6 +70,7 @@
     ],
     "apiVersion": "batch/v1",
     "nameSpaced": true,
+    "isWorkload": true,
     "kind": "CronJob"
   },
   "Kubernetes::Workload::PriorityClass": {

--- a/k8s/k8-resources.json
+++ b/k8s/k8-resources.json
@@ -14,6 +14,7 @@
     "apiVersion": "v1",
     "isWorkload": true,
     "nameSpaced": true,
+    "allowsOwnership": true,
     "kind": "Pod"
   },
   "Kubernetes::Workload::ReplicaSet": {
@@ -61,6 +62,7 @@
     "apiVersion": "batch/v1",
     "isWorkload": true,
     "nameSpaced": true,
+    "allowsOwnership": true,
     "kind": "Job"
   },
   "Kubernetes::Workload::CronJob": {


### PR DESCRIPTION
[Add Kubernetes workload scanner unit consumption to plerion asset counter](https://plerion.atlassian.net/browse/CWPP-1450)

##Summary:
In this PR we add functionality to support showing CWPP asset count and Plerion units consumption for the following K8s resources:
- DaemonSet
- Deployment
- Pod
- StatefulSet
- Job
- CronJob

Algorithm to derive CWPP asset count for K8s:
- If kind is "Pod", then find all ownerless pods and get container counts
- Else find containers

To run asset counter for specific asset types:
`node index.js -p K8S -r ns,pods`. This should result:
```shell
OUTPUT: 
{
  total: 25,
  resources: { namespaces: { KSPM: 5 }, pods: { KSPM: 16, CWPP: 4 } },
  KSPM_UNITS: 21,
  CWPP_UNITS: 40,
  TOTAL_UNITS: 61,
  DAYS_PER_MONTH: 30,
  KSPM_UNITS_PER_MONTH: 630,
  CWPP_UNITS_PER_MONTH: 1200,
  TOTAL_UNITS_PER_MONTH: 1830,
  INFO: {
    KSPM_RESOURCE_UNIT_BASE_CONSUMPTION: 1,
    CWPP_ASSET_UNIT_BASE_CONSUMPTION: 10,
    TOTAL_DAYS_PER_MONTH: 30
  },
  DAILY: {
    KSPM_RESOURCE_UNITS: 21,
    CWPP_ASSET_UNITS: 40,
    TOTAL_RESOURCE_UNITS: 61
  },
  MONTHLY: {
    KSPM_RESOURCE_UNITS: 630,
    CWPP_ASSET_UNITS: 1200,
    TOTAL_RESOURCE_UNITS: 1830
  }
}
-----------------------------------
INFO
KSPM Resource Unit Base Consumption: 1
CWPP Asset Unit Base Consumption: 10
Total days per month: 30
-----------------------------------
DAILY
KSPM Resource Units: 21
CWPP Asset Units: 40
Total Resource Units: 61
-----------------------------------
MONTHLY
KSPM Resource Units consumed p/m: 630
CWPP Asset Units consumed p/m: 1200
Total Resource Units consumed p/m: 1830
```

To run asset counter for specific all K8s asset types:
`node index.js -p K8S`. This should result:
```shell
OUTPUT: 
{
  total: 315,
  resources: {
    podtemplates: { KSPM: 0 },
    pods: { KSPM: 16, CWPP: 4 },
    replicasets: { KSPM: 5 },
    deployments: { KSPM: 5, CWPP: 6 },
    statefulsets: { KSPM: 0, CWPP: 0 },
    daemonsets: { KSPM: 1, CWPP: 1 },
    jobs: { KSPM: 0, CWPP: 0 },
    cronjobs: { KSPM: 0, CWPP: 0 },
    priorityclasses: { KSPM: 2 },
    horizontalpodautoscalers: { KSPM: 0 },
    replicationcontrollers: { KSPM: 0 },
    nodes: { KSPM: 1 },
    namespaces: { KSPM: 5 },
    apiservices: { KSPM: 21 },
    leases: { KSPM: 4 },
    runtimeclasses: { KSPM: 0 },
    flowschemas: { KSPM: 13 },
    prioritylevelconfigurations: { KSPM: 8 },
    services: { KSPM: 5 },
    endpoints: { KSPM: 6 },
    endpointslices: { KSPM: 5 },
    ingresses: { KSPM: 0 },
    ingressclasses: { KSPM: 0 },
    configmaps: { KSPM: 13 },
    secrets: { KSPM: 3 },
    storageclasses: { KSPM: 1 },
    volumeattachments: { KSPM: 0 },
    csidrivers: { KSPM: 0 },
    csinodes: { KSPM: 1 },
    csistoragecapacities: { KSPM: 0 },
    serviceaccounts: { KSPM: 43 },
    clusterroles: { KSPM: 68 },
    clusterrolebindings: { KSPM: 54 },
    roles: { KSPM: 12 },
    rolebindings: { KSPM: 12 },
    limitranges: { KSPM: 0 },
    resourcequotas: { KSPM: 0 },
    networkpolicies: { KSPM: 0 },
    poddisruptionbudgets: { KSPM: 0 },
    customresourcedefinitions: { KSPM: 0 },
    mutatingwebhookconfigurations: { KSPM: 0 },
    validatingwebhookconfigurations: { KSPM: 0 },
    persistentvolumes: { KSPM: 0 },
    persistentvolumeclaims: { KSPM: 0 }
  },
  KSPM_UNITS: 304,
  CWPP_UNITS: 110,
  TOTAL_UNITS: 414,
  DAYS_PER_MONTH: 30,
  KSPM_UNITS_PER_MONTH: 9120,
  CWPP_UNITS_PER_MONTH: 3300,
  TOTAL_UNITS_PER_MONTH: 12420,
  INFO: {
    KSPM_RESOURCE_UNIT_BASE_CONSUMPTION: 1,
    CWPP_ASSET_UNIT_BASE_CONSUMPTION: 10,
    TOTAL_DAYS_PER_MONTH: 30
  },
  DAILY: {
    KSPM_RESOURCE_UNITS: 304,
    CWPP_ASSET_UNITS: 110,
    TOTAL_RESOURCE_UNITS: 414
  },
  MONTHLY: {
    KSPM_RESOURCE_UNITS: 9120,
    CWPP_ASSET_UNITS: 3300,
    TOTAL_RESOURCE_UNITS: 12420
  }
}
-----------------------------------
INFO
KSPM Resource Unit Base Consumption: 1
CWPP Asset Unit Base Consumption: 10
Total days per month: 30
-----------------------------------
DAILY
KSPM Resource Units: 304
CWPP Asset Units: 110
Total Resource Units: 414
-----------------------------------
MONTHLY
KSPM Resource Units consumed p/m: 9120
CWPP Asset Units consumed p/m: 3300
Total Resource Units consumed p/m: 12420
```