### PR TITLE
feat: PL-5199 add docker dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
## Summary

- Adds `.github/dependabot.yml` with `docker` ecosystem to automate weekly updates of pinned SHA hashes in Dockerfiles
- Ignores major version bumps to avoid breaking changes
- Part of PL-5199: automate pinned SHA hash updates for Docker base images (follow-up to MI-84 security hardening)